### PR TITLE
Add convenience method on iOS for adding Layers

### DIFF
--- a/ios/readme.md
+++ b/ios/readme.md
@@ -136,7 +136,7 @@ class MapViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
       
-    mapView.add(layer: rasterLayer?.asLayerInterface())
+    mapView.add(layer: rasterLayer)
   }
 }
 ```


### PR DESCRIPTION
- this allows abitrary objects which implement the method `func asLayerInterface() -> MCLayerInterface` to be added as layers