### PR TITLE
fixes iOS retain cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for Open Mobile Maps
 
+## next version
+
+- fixes iOS retain cycle
+
 ## Version 1.3.0 (09.03.2021)
 
 - Native library and relevant header files are now properly included in the published dependency

--- a/ios/maps/MCMapView.swift
+++ b/ios/maps/MCMapView.swift
@@ -24,6 +24,7 @@ open class MCMapView: MTKView {
     private let framesToRenderAfterInvalidate: UInt = 1
 
     private let touchHandler: MCMapViewTouchHandler
+    private let callbackHandler = MCMapViewCallbackHandler()
 
     public init(mapConfig: MCMapConfig) {
         let renderingContext = RenderingContext()
@@ -61,7 +62,10 @@ open class MCMapView: MTKView {
 
         isMultipleTouchEnabled = true
 
-        mapInterface.setCallbackHandler(self)
+        callbackHandler.invalidateCallback = { [weak self] in
+            self?.invalidate()
+        }
+        mapInterface.setCallbackHandler(callbackHandler)
 
         touchHandler.mapView = self
 
@@ -100,9 +104,7 @@ open class MCMapView: MTKView {
             isOpaque = newValue?.isOpaque ?? false
         }
     }
-}
 
-extension MCMapView: MCMapCallbackInterface {
     public func invalidate() {
         isPaused = false
         framesToRender = framesToRenderAfterInvalidate

--- a/ios/maps/MCMapViewCallbackHandler.swift
+++ b/ios/maps/MCMapViewCallbackHandler.swift
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021 Ubique Innovation AG <https://www.ubique.ch>
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ *  SPDX-License-Identifier: MPL-2.0
+ */
+
+
+import Foundation
+import MapCoreSharedModule
+
+class MCMapViewCallbackHandler: MCMapCallbackInterface {
+    var invalidateCallback: (()->())?
+
+    func invalidate() {
+        invalidateCallback?()
+    }
+}


### PR DESCRIPTION
This fixes a retain cycle in the iOS code which was introduced by `mapInterface.setCallbackHandler(self)`. This fixes Issue #56 