### PR TITLE
Android Proguard/Lifecycle Fix

### DIFF
--- a/android/consumer-rules.pro
+++ b/android/consumer-rules.pro
@@ -1,2 +1,2 @@
 
--keep class ch.ubique.graphicscore.shared.** { *; }
+-keep class io.openmobilemaps.mapscore.shared.** { *; }

--- a/android/src/main/java/io/openmobilemaps/mapscore/map/view/MapView.kt
+++ b/android/src/main/java/io/openmobilemaps/mapscore/map/view/MapView.kt
@@ -67,8 +67,8 @@ open class MapView @JvmOverloads constructor(context: Context, attrs: AttributeS
 	}
 
 	fun registerLifecycle(lifecycle: Lifecycle) {
-		lifecycle.addObserver(this)
 		scheduler.setCoroutineScope(lifecycle.coroutineScope)
+		lifecycle.addObserver(this)
 	}
 
 	override fun onSurfaceCreated(gl: GL10?, config: EGLConfig?) {


### PR DESCRIPTION
Exclude reflection-dependant generated files from obfuscation/optimization, fixed a crash when registering an already started lifecycle