### PR TITLE
Added asGraphicsObjects for MaskInterfaces, setup/clear in layer

### DIFF
--- a/bridging/android/java/io/openmobilemaps/mapscore/shared/graphics/objects/MaskingObjectInterface.kt
+++ b/bridging/android/java/io/openmobilemaps/mapscore/shared/graphics/objects/MaskingObjectInterface.kt
@@ -9,6 +9,8 @@ abstract class MaskingObjectInterface {
 
     abstract fun renderAsMask(context: io.openmobilemaps.mapscore.shared.graphics.RenderingContextInterface, renderPass: io.openmobilemaps.mapscore.shared.graphics.RenderPassConfig, mvpMatrix: Long, screenPixelAsRealMeterFactor: Double)
 
+    abstract fun asGraphicsObject(): GraphicsObjectInterface
+
     private class CppProxy : MaskingObjectInterface {
         private val nativeRef: Long
         private val destroyed: AtomicBoolean = AtomicBoolean(false)
@@ -32,5 +34,11 @@ abstract class MaskingObjectInterface {
             native_renderAsMask(this.nativeRef, context, renderPass, mvpMatrix, screenPixelAsRealMeterFactor)
         }
         private external fun native_renderAsMask(_nativeRef: Long, context: io.openmobilemaps.mapscore.shared.graphics.RenderingContextInterface, renderPass: io.openmobilemaps.mapscore.shared.graphics.RenderPassConfig, mvpMatrix: Long, screenPixelAsRealMeterFactor: Double)
+
+        override fun asGraphicsObject(): GraphicsObjectInterface {
+            assert(!this.destroyed.get()) { error("trying to use a destroyed object") }
+            return native_asGraphicsObject(this.nativeRef)
+        }
+        private external fun native_asGraphicsObject(_nativeRef: Long): GraphicsObjectInterface
     }
 }

--- a/bridging/android/jni/graphics/objects/NativeMaskingObjectInterface.cpp
+++ b/bridging/android/jni/graphics/objects/NativeMaskingObjectInterface.cpp
@@ -3,6 +3,7 @@
 
 #include "NativeMaskingObjectInterface.h"  // my header
 #include "Marshal.hpp"
+#include "NativeGraphicsObjectInterface.h"
 #include "NativeRenderPassConfig.h"
 #include "NativeRenderingContextInterface.h"
 
@@ -27,6 +28,14 @@ void NativeMaskingObjectInterface::JavaProxy::renderAsMask(const std::shared_ptr
                            ::djinni::get(::djinni::F64::fromCpp(jniEnv, c_screenPixelAsRealMeterFactor)));
     ::djinni::jniExceptionCheck(jniEnv);
 }
+std::shared_ptr<::GraphicsObjectInterface> NativeMaskingObjectInterface::JavaProxy::asGraphicsObject() {
+    auto jniEnv = ::djinni::jniGetThreadEnv();
+    ::djinni::JniLocalScope jscope(jniEnv, 10);
+    const auto& data = ::djinni::JniClass<::djinni_generated::NativeMaskingObjectInterface>::get();
+    auto jret = jniEnv->CallObjectMethod(Handle::get().get(), data.method_asGraphicsObject);
+    ::djinni::jniExceptionCheck(jniEnv);
+    return ::djinni_generated::NativeGraphicsObjectInterface::toCpp(jniEnv, jret);
+}
 
 CJNIEXPORT void JNICALL Java_io_openmobilemaps_mapscore_shared_graphics_objects_MaskingObjectInterface_00024CppProxy_nativeDestroy(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef)
 {
@@ -46,6 +55,16 @@ CJNIEXPORT void JNICALL Java_io_openmobilemaps_mapscore_shared_graphics_objects_
                           ::djinni::I64::toCpp(jniEnv, j_mvpMatrix),
                           ::djinni::F64::toCpp(jniEnv, j_screenPixelAsRealMeterFactor));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
+}
+
+CJNIEXPORT jobject JNICALL Java_io_openmobilemaps_mapscore_shared_graphics_objects_MaskingObjectInterface_00024CppProxy_native_1asGraphicsObject(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::MaskingObjectInterface>(nativeRef);
+        auto r = ref->asGraphicsObject();
+        return ::djinni::release(::djinni_generated::NativeGraphicsObjectInterface::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
 }  // namespace djinni_generated

--- a/bridging/android/jni/graphics/objects/NativeMaskingObjectInterface.h
+++ b/bridging/android/jni/graphics/objects/NativeMaskingObjectInterface.h
@@ -34,6 +34,7 @@ private:
         ~JavaProxy();
 
         void renderAsMask(const std::shared_ptr<::RenderingContextInterface> & context, const ::RenderPassConfig & renderPass, int64_t mvpMatrix, double screenPixelAsRealMeterFactor) override;
+        std::shared_ptr<::GraphicsObjectInterface> asGraphicsObject() override;
 
     private:
         friend ::djinni::JniInterface<::MaskingObjectInterface, ::djinni_generated::NativeMaskingObjectInterface>;
@@ -41,6 +42,7 @@ private:
 
     const ::djinni::GlobalRef<jclass> clazz { ::djinni::jniFindClass("io/openmobilemaps/mapscore/shared/graphics/objects/MaskingObjectInterface") };
     const jmethodID method_renderAsMask { ::djinni::jniGetMethodID(clazz.get(), "renderAsMask", "(Lio/openmobilemaps/mapscore/shared/graphics/RenderingContextInterface;Lio/openmobilemaps/mapscore/shared/graphics/RenderPassConfig;JD)V") };
+    const jmethodID method_asGraphicsObject { ::djinni::jniGetMethodID(clazz.get(), "asGraphicsObject", "()Lio/openmobilemaps/mapscore/shared/graphics/objects/GraphicsObjectInterface;") };
 };
 
 }  // namespace djinni_generated

--- a/bridging/ios/MCMaskingObjectInterface+Private.mm
+++ b/bridging/ios/MCMaskingObjectInterface+Private.mm
@@ -7,6 +7,7 @@
 #import "DJIError.h"
 #import "DJIMarshal+Private.h"
 #import "DJIObjcWrapperCache+Private.h"
+#import "MCGraphicsObjectInterface+Private.h"
 #import "MCRenderPassConfig+Private.h"
 #import "MCRenderingContextInterface+Private.h"
 #include <exception>
@@ -45,6 +46,13 @@ screenPixelAsRealMeterFactor:(double)screenPixelAsRealMeterFactor {
     } DJINNI_TRANSLATE_EXCEPTIONS()
 }
 
+- (nullable id<MCGraphicsObjectInterface>)asGraphicsObject {
+    try {
+        auto objcpp_result_ = _cppRefHandle.get()->asGraphicsObject();
+        return ::djinni_generated::GraphicsObjectInterface::fromCpp(objcpp_result_);
+    } DJINNI_TRANSLATE_EXCEPTIONS()
+}
+
 namespace djinni_generated {
 
 class MaskingObjectInterface::ObjcProxy final
@@ -61,6 +69,13 @@ public:
                                                         renderPass:(::djinni_generated::RenderPassConfig::fromCpp(c_renderPass))
                                                          mvpMatrix:(::djinni::I64::fromCpp(c_mvpMatrix))
                                       screenPixelAsRealMeterFactor:(::djinni::F64::fromCpp(c_screenPixelAsRealMeterFactor))];
+        }
+    }
+    std::shared_ptr<::GraphicsObjectInterface> asGraphicsObject() override
+    {
+        @autoreleasepool {
+            auto objcpp_result_ = [djinni_private_get_proxied_objc_object() asGraphicsObject];
+            return ::djinni_generated::GraphicsObjectInterface::toCpp(objcpp_result_);
         }
     }
 };

--- a/bridging/ios/MCMaskingObjectInterface.h
+++ b/bridging/ios/MCMaskingObjectInterface.h
@@ -4,6 +4,7 @@
 #import "MCRenderPassConfig.h"
 #import "MCRenderingContextInterface.h"
 #import <Foundation/Foundation.h>
+@protocol MCGraphicsObjectInterface;
 
 
 @protocol MCMaskingObjectInterface
@@ -12,5 +13,7 @@
           renderPass:(nonnull MCRenderPassConfig *)renderPass
            mvpMatrix:(int64_t)mvpMatrix
 screenPixelAsRealMeterFactor:(double)screenPixelAsRealMeterFactor;
+
+- (nullable id<MCGraphicsObjectInterface>)asGraphicsObject;
 
 @end

--- a/djinni/graphics/objects/graphicsobjects.djinni
+++ b/djinni/graphics/objects/graphicsobjects.djinni
@@ -13,10 +13,13 @@ graphics_object_interface = interface +c +j +o {
     # Clear graphics object and invalidate isReady
     clear();
     # Render the graphics object; ensure calling on graphics thread
-    render(context: rendering_context_interface, render_pass: render_pass_config, mvp_matrix: i64, is_masked: bool, screenPixelAsRealMeterFactor: f64);}
+    render(context: rendering_context_interface, render_pass: render_pass_config, mvp_matrix: i64, is_masked: bool, screenPixelAsRealMeterFactor: f64);
+}
 
 masking_object_interface = interface +c +j +o {
-	render_as_mask(context: rendering_context_interface, render_pass: render_pass_config, mvp_matrix: i64, screenPixelAsRealMeterFactor: f64);}
+	render_as_mask(context: rendering_context_interface, render_pass: render_pass_config, mvp_matrix: i64, screenPixelAsRealMeterFactor: f64);
+    as_graphics_object(): graphics_object_interface;
+}
 
 graphics_object_factory_interface = interface +c +j +o {
     create_quad(shader: shader_program_interface) : quad_2d_interface;

--- a/shared/public/MaskingObjectInterface.h
+++ b/shared/public/MaskingObjectInterface.h
@@ -8,9 +8,13 @@
 #include <cstdint>
 #include <memory>
 
+class GraphicsObjectInterface;
+
 class MaskingObjectInterface {
 public:
     virtual ~MaskingObjectInterface() {}
 
     virtual void renderAsMask(const std::shared_ptr<::RenderingContextInterface> & context, const ::RenderPassConfig & renderPass, int64_t mvpMatrix, double screenPixelAsRealMeterFactor) = 0;
+
+    virtual std::shared_ptr<GraphicsObjectInterface> asGraphicsObject() = 0;
 };

--- a/shared/src/map/layers/icon/IconLayer.cpp
+++ b/shared/src/map/layers/icon/IconLayer.cpp
@@ -145,6 +145,9 @@ void IconLayer::clear() {
                 }));
         icons.clear();
     }
+    if (mask) {
+        if (mask->asGraphicsObject()->isReady()) mask->asGraphicsObject()->clear();
+    }
     renderPassObjectMap.clear();
     if (mapInterface)
         mapInterface->invalidate();
@@ -257,6 +260,9 @@ void IconLayer::resume() {
         addingQueue.clear();
         addIcons(icons);
     }
+    if (mask) {
+        if (!mask->asGraphicsObject()->isReady()) mask->asGraphicsObject()->setup(mapInterface->getRenderingContext());
+    }
 }
 
 void IconLayer::hide() {
@@ -319,5 +325,10 @@ bool IconLayer::onClickConfirmed(const Vec2F &posScreen) {
 
 void IconLayer::setMaskingObject(const std::shared_ptr<::MaskingObjectInterface> & maskingObject) {
     this->mask = maskingObject;
-    if (mapInterface) mapInterface->invalidate();
+    if (mapInterface) {
+        if (mask) {
+            if (!mask->asGraphicsObject()->isReady()) mask->asGraphicsObject()->setup(mapInterface->getRenderingContext());
+        }
+        mapInterface->invalidate();
+    }
 }

--- a/shared/src/map/layers/tiled/raster/Tiled2dMapRasterLayer.cpp
+++ b/shared/src/map/layers/tiled/raster/Tiled2dMapRasterLayer.cpp
@@ -60,6 +60,9 @@ void Tiled2dMapRasterLayer::pause() {
     for (const auto &tileObject : tileObjectMap) {
         if (tileObject.second && tileObject.second->getQuadObject()->asGraphicsObject()->isReady()) tileObject.second->getQuadObject()->asGraphicsObject()->clear();
     }
+    if (mask) {
+        if (mask->asGraphicsObject()->isReady()) mask->asGraphicsObject()->clear();
+    }
 }
 
 void Tiled2dMapRasterLayer::resume() {
@@ -72,6 +75,9 @@ void Tiled2dMapRasterLayer::resume() {
             rectangle->asGraphicsObject()->setup(renderingContext);
             rectangle->loadTexture(tileObject.first.textureHolder);
         }
+    }
+    if (mask) {
+        if (!mask->asGraphicsObject()->isReady()) mask->asGraphicsObject()->setup(renderingContext);
     }
 }
 
@@ -218,5 +224,10 @@ bool Tiled2dMapRasterLayer::onLongPress(const Vec2F &posScreen) {
 void Tiled2dMapRasterLayer::setMaskingObject(const std::shared_ptr<::MaskingObjectInterface> &maskingObject) {
     mask = maskingObject;
     generateRenderPasses();
-    if (mapInterface) mapInterface->invalidate();
+    if (mapInterface) {
+        if (mask) {
+            if (!mask->asGraphicsObject()->isReady()) mask->asGraphicsObject()->setup(mapInterface->getRenderingContext());
+        }
+        mapInterface->invalidate();
+    }
 }


### PR DESCRIPTION
For convenience, masks are now set up and cleared in the layer they're added to.