### PR TITLE
TileLoader bounds and GLSL clamp

### DIFF
--- a/android/src/main/cpp/graphics/shader/ColorLineGroup2dShaderOpenGl.cpp
+++ b/android/src/main/cpp/graphics/shader/ColorLineGroup2dShaderOpenGl.cpp
@@ -117,7 +117,12 @@ std::string  ColorLineGroup2dShaderOpenGl::getVertexShader() {
 
             void main() {
                 float fStyleIndex = mod(vStyleInfo, 256.0);
-                int lineIndex = clamp(int(floor(fStyleIndex + 0.5)), 0, numStyles);
+                int lineIndex = int(floor(fStyleIndex + 0.5));
+                if (lineIndex < 0) {
+                    lineIndex = 0;
+                } else if (lineIndex > numStyles) {
+                    lineIndex = numStyles;
+                }
                 int styleIndexBase = 7 * lineIndex;
                 float width = lineStyles[styleIndexBase];
                 float isScaled = lineStyles[styleIndexBase + 1];

--- a/android/src/main/cpp/graphics/shader/ColorPolygonGroup2dShaderOpenGl.cpp
+++ b/android/src/main/cpp/graphics/shader/ColorPolygonGroup2dShaderOpenGl.cpp
@@ -88,7 +88,13 @@ std::string ColorPolygonGroup2dShaderOpenGl::getVertexShader() {
             varying vec4 color;
 
             void main() {
-                int styleIndex = 4 * clamp(int(floor(vStyleIndex + 0.5)), 0, numStyles);
+                int styleIndex = int(floor(vStyleIndex + 0.5));
+                if (styleIndex < 0) {
+                    styleIndex = 0;
+                } else if (styleIndex > numStyles) {
+                    styleIndex = numStyles;
+                }
+                styleIndex = styleIndex * 4;
                 color = vec4(polygonStyles[styleIndex], polygonStyles[styleIndex + 1], polygonStyles[styleIndex + 2], polygonStyles[styleIndex + 3]);
                 gl_Position = uMVPMatrix * vec4(vPosition, 0.0, 1.0);
             });

--- a/shared/public/Tiled2dMapSourceImpl.h
+++ b/shared/public/Tiled2dMapSourceImpl.h
@@ -110,12 +110,19 @@ template <class T, class L, class R> void Tiled2dMapSource<T, L, R>::updateCurre
 
         for (int x = startTileLeft; x <= maxTileLeft && x < zoomLevelInfo.numTilesX; x++) {
             for (int y = startTileTop; y <= maxTileTop && y < zoomLevelInfo.numTilesY; y++) {
-                Coord tileTopLeft = Coord(layerSystemId, x * tileWidthAdj + boundsLeft, y * tileHeightAdj + boundsTop, 0);
-                Coord tileBottomRight = Coord(layerSystemId, tileTopLeft.x + tileWidthAdj, tileTopLeft.y + tileHeightAdj, 0);
-                RectCoord rect(tileTopLeft, tileBottomRight);
+                Coord minCorner = Coord(layerSystemId, x * tileWidthAdj + boundsLeft, y * tileHeightAdj + boundsTop, 0);
+                Coord maxCorner = Coord(layerSystemId, minCorner.x + tileWidthAdj, minCorner.y + tileHeightAdj, 0);
+                RectCoord rect(Coord(layerSystemId,
+                                     leftToRight ? minCorner.x : maxCorner.x,
+                                     topToBottom ? minCorner.y : maxCorner.y,
+                                     0.0),
+                               Coord(layerSystemId,
+                                     leftToRight ? maxCorner.x : minCorner.x,
+                                     topToBottom ? maxCorner.y : minCorner.y,
+                                     0.0));
 
-                double tileCenterX = tileTopLeft.x + 0.5f * (tileBottomRight.x - tileTopLeft.x);
-                double tileCenterY = tileTopLeft.y + 0.5f * (tileBottomRight.y - tileTopLeft.y);
+                double tileCenterX = minCorner.x + 0.5f * (maxCorner.x - minCorner.x);
+                double tileCenterY = minCorner.y + 0.5f * (maxCorner.y - minCorner.y);
                 double tileCenterDis =
                     std::sqrt(std::pow(tileCenterX - centerVisibleX, 2.0) + std::pow(tileCenterY - centerVisibleY, 2.0));
 


### PR DESCRIPTION
Fix ColorGroup shaders for devices with limited clamp support, fix orientation of bounds for loaded tiles.