### PR TITLE
OpenGL Quad Texture Coordinates

### DIFF
--- a/android/src/main/cpp/graphics/objects/Quad2dOpenGl.cpp
+++ b/android/src/main/cpp/graphics/objects/Quad2dOpenGl.cpp
@@ -173,12 +173,12 @@ void Quad2dOpenGl::render(const std::shared_ptr<::RenderingContextInterface> &co
 
     if (textureLoaded) {
         prepareTextureDraw(openGlContext, mProgram);
-
-        glEnableVertexAttribArray(textureCoordinateHandle);
-        glBindBuffer(GL_ARRAY_BUFFER, textureCoordsBuffer);
-        glVertexAttribPointer(textureCoordinateHandle, 2, GL_FLOAT, false, 0, nullptr);
-        OpenGlHelper::checkGlError("glEnableVertexAttribArray texCoordinate");
     }
+
+    glEnableVertexAttribArray(textureCoordinateHandle);
+    glBindBuffer(GL_ARRAY_BUFFER, textureCoordsBuffer);
+    glVertexAttribPointer(textureCoordinateHandle, 2, GL_FLOAT, false, 0, nullptr);
+    OpenGlHelper::checkGlError("glEnableVertexAttribArray texCoordinate");
 
     shaderProgram->preRender(context);
 

--- a/shared/src/graphics/Renderer.cpp
+++ b/shared/src/graphics/Renderer.cpp
@@ -37,7 +37,7 @@ void Renderer::drawFrame(const std::shared_ptr<RenderingContextInterface> &rende
             const auto &renderObjects = pass->getRenderObjects();
             std::vector<float> tempMvpMatrix(16, 0);
 
-            if (maskObject) {
+            if (hasMask) {
                 renderingContext->preRenderStencilMask();
                 maskObject->renderAsMask(renderingContext, pass->getRenderPassConfig(), vpMatrixPointer, factor);
             }
@@ -53,7 +53,7 @@ void Renderer::drawFrame(const std::shared_ptr<RenderingContextInterface> &rende
                 }
             }
 
-            if (maskObject) {
+            if (hasMask) {
                 renderingContext->postRenderStencilMask();
             }
         }


### PR DESCRIPTION
Provide texture coords in OpenGl quad, even when no texture is loaded.