### PR TITLE
iOS: set stencil buffer to default mask if not masked

### DIFF
--- a/ios/graphics/Model/Quad2d.swift
+++ b/ios/graphics/Model/Quad2d.swift
@@ -26,6 +26,8 @@ class Quad2d: BaseGraphicsObject {
 
     private var stencilState: MTLDepthStencilState?
 
+    private var defaultStencilState: MTLDepthStencilState?
+
     init(shader: MCShaderProgramInterface, metalContext: MetalContext) {
         self.shader = shader
         super.init(device: metalContext.device,
@@ -48,6 +50,16 @@ class Quad2d: BaseGraphicsObject {
         stencilState = device.makeDepthStencilState(descriptor: s2)
     }
 
+    private func setupDefaultStencilStates() {
+        let ss2 = MTLStencilDescriptor()
+        ss2.stencilCompareFunction = .always
+        ss2.depthStencilPassOperation = .keep
+        let s2 = MTLDepthStencilDescriptor()
+        s2.frontFaceStencil = ss2
+        s2.backFaceStencil = ss2
+        defaultStencilState = device.makeDepthStencilState(descriptor: s2)
+    }
+
     override func render(encoder: MTLRenderCommandEncoder,
                          context: RenderingContext,
                          renderPass _: MCRenderPassConfig,
@@ -66,6 +78,8 @@ class Quad2d: BaseGraphicsObject {
             }
             encoder.setDepthStencilState(stencilState)
             encoder.setStencilReferenceValue(0b1000_0000)
+        } else {
+            encoder.setDepthStencilState(context.defaultMask)
         }
 
         shader.setupProgram(context)

--- a/ios/graphics/Model/Quad2d.swift
+++ b/ios/graphics/Model/Quad2d.swift
@@ -26,8 +26,6 @@ class Quad2d: BaseGraphicsObject {
 
     private var stencilState: MTLDepthStencilState?
 
-    private var defaultStencilState: MTLDepthStencilState?
-
     init(shader: MCShaderProgramInterface, metalContext: MetalContext) {
         self.shader = shader
         super.init(device: metalContext.device,
@@ -48,16 +46,6 @@ class Quad2d: BaseGraphicsObject {
         s2.backFaceStencil = ss2
 
         stencilState = device.makeDepthStencilState(descriptor: s2)
-    }
-
-    private func setupDefaultStencilStates() {
-        let ss2 = MTLStencilDescriptor()
-        ss2.stencilCompareFunction = .always
-        ss2.depthStencilPassOperation = .keep
-        let s2 = MTLDepthStencilDescriptor()
-        s2.frontFaceStencil = ss2
-        s2.backFaceStencil = ss2
-        defaultStencilState = device.makeDepthStencilState(descriptor: s2)
     }
 
     override func render(encoder: MTLRenderCommandEncoder,

--- a/ios/graphics/Model/Text/Text.swift
+++ b/ios/graphics/Model/Text/Text.swift
@@ -61,6 +61,8 @@ class Text: BaseGraphicsObject {
             }
             encoder.setDepthStencilState(stencilState)
             encoder.setStencilReferenceValue(0b1000_0000)
+        } else {
+            encoder.setDepthStencilState(context.defaultMask)
         }
 
         encoder.pushDebugGroup("Text")

--- a/ios/graphics/RenderingContext.swift
+++ b/ios/graphics/RenderingContext.swift
@@ -43,6 +43,16 @@ public class RenderingContext: NSObject {
         return MetalContext.current.device.makeDepthStencilState(descriptor: depthStencilDescriptor)
     }()
 
+    public lazy var defaultMask: MTLDepthStencilState? = {
+        let descriptor = MTLStencilDescriptor()
+        descriptor.stencilCompareFunction = .always
+        descriptor.depthStencilPassOperation = .keep
+        let depthStencilDescriptor = MTLDepthStencilDescriptor()
+        depthStencilDescriptor.frontFaceStencil = descriptor
+        depthStencilDescriptor.backFaceStencil = descriptor
+        return MetalContext.current.device.makeDepthStencilState(descriptor: depthStencilDescriptor)
+    }()
+
     public var viewportSize: MCVec2I = .init(x: 0, y: 0)
 
     /// a Quad that fills the whole viewport


### PR DESCRIPTION
this ignores the content of the stencil buffer