### PR TITLE
OnRemove Fix / TouchListener Remove Fix

### DIFF
--- a/shared/src/map/MapScene.cpp
+++ b/shared/src/map/MapScene.cpp
@@ -147,17 +147,18 @@ void MapScene::insertLayerBelow(const std::shared_ptr<LayerInterface> &layer, co
 };
 
 void MapScene::removeLayer(const std::shared_ptr<::LayerInterface> &layer) {
-    layer->onRemoved();
-    std::lock_guard<std::recursive_mutex> lock(layersMutex);
-    int targetIndex = -1;
-    for (const auto &[i, l] : layers) {
-        if (l == layer) {
-            targetIndex = i;
-            l->onRemoved();
-            break;
+    {
+        std::lock_guard<std::recursive_mutex> lock(layersMutex);
+        int targetIndex = -1;
+        for (const auto &[i, l] : layers) {
+            if (l == layer) {
+                targetIndex = i;
+                break;
+            }
         }
+        if (targetIndex > 0) layers.erase(targetIndex);
     }
-    if (targetIndex > 0) layers.erase(targetIndex);
+    layer->onRemoved();
 }
 
 void MapScene::setViewportSize(const ::Vec2I &size) {

--- a/shared/src/map/camera/MapCamera2d.cpp
+++ b/shared/src/map/camera/MapCamera2d.cpp
@@ -251,12 +251,16 @@ void MapCamera2d::setPaddingBottom(float padding) {
 
 void MapCamera2d::addListener(const std::shared_ptr<MapCamera2dListenerInterface> &listener) {
     std::lock_guard<std::recursive_mutex> lock(listenerMutex);
-    listeners.insert(listener);
+    if (listeners.count(listener) == 0) {
+        listeners.insert(listener);
+    }
 }
 
 void MapCamera2d::removeListener(const std::shared_ptr<MapCamera2dListenerInterface> &listener) {
     std::lock_guard<std::recursive_mutex> lock(listenerMutex);
-    listeners.erase(listener);
+    if (listeners.count(listener) > 0) {
+        listeners.erase(listener);
+    }
 }
 
 std::shared_ptr<::CameraInterface> MapCamera2d::asCameraInterface() { return shared_from_this(); }


### PR DESCRIPTION
Don't call layer onRemoved() twice, fix crash in camera when removing non-existing listener.