### PR TITLE
Calculate tiled layer scale in Tiled2dMapSourceImpl

### DIFF
--- a/bridging/android/java/io/openmobilemaps/mapscore/shared/map/MapCamera2dInterface.kt
+++ b/bridging/android/java/io/openmobilemaps/mapscore/shared/map/MapCamera2dInterface.kt
@@ -51,6 +51,8 @@ abstract class MapCamera2dInterface {
 
     abstract fun getPaddingAdjustedVisibleRect(): io.openmobilemaps.mapscore.shared.map.coordinates.RectCoord
 
+    abstract fun getScreenDensityPpi(): Float
+
     /** this method is called just before the update methods on all layers */
     abstract fun update()
 
@@ -232,6 +234,12 @@ abstract class MapCamera2dInterface {
             return native_getPaddingAdjustedVisibleRect(this.nativeRef)
         }
         private external fun native_getPaddingAdjustedVisibleRect(_nativeRef: Long): io.openmobilemaps.mapscore.shared.map.coordinates.RectCoord
+
+        override fun getScreenDensityPpi(): Float {
+            assert(!this.destroyed.get()) { error("trying to use a destroyed object") }
+            return native_getScreenDensityPpi(this.nativeRef)
+        }
+        private external fun native_getScreenDensityPpi(_nativeRef: Long): Float
 
         override fun update() {
             assert(!this.destroyed.get()) { error("trying to use a destroyed object") }

--- a/bridging/android/java/io/openmobilemaps/mapscore/shared/map/layers/tiled/Tiled2dMapZoomInfo.kt
+++ b/bridging/android/java/io/openmobilemaps/mapscore/shared/map/layers/tiled/Tiled2dMapZoomInfo.kt
@@ -6,4 +6,5 @@ package io.openmobilemaps.mapscore.shared.map.layers.tiled
 data class Tiled2dMapZoomInfo(
     var zoomLevelScaleFactor: Float,
     var numDrawPreviousLayers: Int,
+    var adaptScaleToScreen: Boolean,
 )

--- a/bridging/android/jni/map/NativeMapCamera2dInterface.cpp
+++ b/bridging/android/jni/map/NativeMapCamera2dInterface.cpp
@@ -250,6 +250,16 @@ CJNIEXPORT ::djinni_generated::NativeRectCoord::JniType JNICALL Java_io_openmobi
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
+CJNIEXPORT jfloat JNICALL Java_io_openmobilemaps_mapscore_shared_map_MapCamera2dInterface_00024CppProxy_native_1getScreenDensityPpi(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::MapCamera2dInterface>(nativeRef);
+        auto r = ref->getScreenDensityPpi();
+        return ::djinni::release(::djinni::F32::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
 CJNIEXPORT void JNICALL Java_io_openmobilemaps_mapscore_shared_map_MapCamera2dInterface_00024CppProxy_native_1update(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef)
 {
     try {

--- a/bridging/android/jni/map/layers/tiled/NativeTiled2dMapZoomInfo.cpp
+++ b/bridging/android/jni/map/layers/tiled/NativeTiled2dMapZoomInfo.cpp
@@ -14,17 +14,19 @@ auto NativeTiled2dMapZoomInfo::fromCpp(JNIEnv* jniEnv, const CppType& c) -> ::dj
     const auto& data = ::djinni::JniClass<NativeTiled2dMapZoomInfo>::get();
     auto r = ::djinni::LocalRef<JniType>{jniEnv->NewObject(data.clazz.get(), data.jconstructor,
                                                            ::djinni::get(::djinni::F32::fromCpp(jniEnv, c.zoomLevelScaleFactor)),
-                                                           ::djinni::get(::djinni::I32::fromCpp(jniEnv, c.numDrawPreviousLayers)))};
+                                                           ::djinni::get(::djinni::I32::fromCpp(jniEnv, c.numDrawPreviousLayers)),
+                                                           ::djinni::get(::djinni::Bool::fromCpp(jniEnv, c.adaptScaleToScreen)))};
     ::djinni::jniExceptionCheck(jniEnv);
     return r;
 }
 
 auto NativeTiled2dMapZoomInfo::toCpp(JNIEnv* jniEnv, JniType j) -> CppType {
-    ::djinni::JniLocalScope jscope(jniEnv, 3);
+    ::djinni::JniLocalScope jscope(jniEnv, 4);
     assert(j != nullptr);
     const auto& data = ::djinni::JniClass<NativeTiled2dMapZoomInfo>::get();
     return {::djinni::F32::toCpp(jniEnv, jniEnv->GetFloatField(j, data.field_zoomLevelScaleFactor)),
-            ::djinni::I32::toCpp(jniEnv, jniEnv->GetIntField(j, data.field_numDrawPreviousLayers))};
+            ::djinni::I32::toCpp(jniEnv, jniEnv->GetIntField(j, data.field_numDrawPreviousLayers)),
+            ::djinni::Bool::toCpp(jniEnv, jniEnv->GetBooleanField(j, data.field_adaptScaleToScreen))};
 }
 
 }  // namespace djinni_generated

--- a/bridging/android/jni/map/layers/tiled/NativeTiled2dMapZoomInfo.h
+++ b/bridging/android/jni/map/layers/tiled/NativeTiled2dMapZoomInfo.h
@@ -25,9 +25,10 @@ private:
     friend ::djinni::JniClass<NativeTiled2dMapZoomInfo>;
 
     const ::djinni::GlobalRef<jclass> clazz { ::djinni::jniFindClass("io/openmobilemaps/mapscore/shared/map/layers/tiled/Tiled2dMapZoomInfo") };
-    const jmethodID jconstructor { ::djinni::jniGetMethodID(clazz.get(), "<init>", "(FI)V") };
+    const jmethodID jconstructor { ::djinni::jniGetMethodID(clazz.get(), "<init>", "(FIZ)V") };
     const jfieldID field_zoomLevelScaleFactor { ::djinni::jniGetFieldID(clazz.get(), "zoomLevelScaleFactor", "F") };
     const jfieldID field_numDrawPreviousLayers { ::djinni::jniGetFieldID(clazz.get(), "numDrawPreviousLayers", "I") };
+    const jfieldID field_adaptScaleToScreen { ::djinni::jniGetFieldID(clazz.get(), "adaptScaleToScreen", "Z") };
 };
 
 }  // namespace djinni_generated

--- a/bridging/ios/MCMapCamera2dInterface+Private.mm
+++ b/bridging/ios/MCMapCamera2dInterface+Private.mm
@@ -202,6 +202,13 @@ static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for th
     } DJINNI_TRANSLATE_EXCEPTIONS()
 }
 
+- (float)getScreenDensityPpi {
+    try {
+        auto objcpp_result_ = _cppRefHandle.get()->getScreenDensityPpi();
+        return ::djinni::F32::fromCpp(objcpp_result_);
+    } DJINNI_TRANSLATE_EXCEPTIONS()
+}
+
 - (void)update {
     try {
         _cppRefHandle.get()->update();

--- a/bridging/ios/MCMapCamera2dInterface.h
+++ b/bridging/ios/MCMapCamera2dInterface.h
@@ -68,6 +68,8 @@
 
 - (nonnull MCRectCoord *)getPaddingAdjustedVisibleRect;
 
+- (float)getScreenDensityPpi;
+
 /** this method is called just before the update methods on all layers */
 - (void)update;
 

--- a/bridging/ios/MCTiled2dMapZoomInfo+Private.mm
+++ b/bridging/ios/MCTiled2dMapZoomInfo+Private.mm
@@ -11,13 +11,15 @@ auto Tiled2dMapZoomInfo::toCpp(ObjcType obj) -> CppType
 {
     assert(obj);
     return {::djinni::F32::toCpp(obj.zoomLevelScaleFactor),
-            ::djinni::I32::toCpp(obj.numDrawPreviousLayers)};
+            ::djinni::I32::toCpp(obj.numDrawPreviousLayers),
+            ::djinni::Bool::toCpp(obj.adaptScaleToScreen)};
 }
 
 auto Tiled2dMapZoomInfo::fromCpp(const CppType& cpp) -> ObjcType
 {
     return [[MCTiled2dMapZoomInfo alloc] initWithZoomLevelScaleFactor:(::djinni::F32::fromCpp(cpp.zoomLevelScaleFactor))
-                                                numDrawPreviousLayers:(::djinni::I32::fromCpp(cpp.numDrawPreviousLayers))];
+                                                numDrawPreviousLayers:(::djinni::I32::fromCpp(cpp.numDrawPreviousLayers))
+                                                   adaptScaleToScreen:(::djinni::Bool::fromCpp(cpp.adaptScaleToScreen))];
 }
 
 }  // namespace djinni_generated

--- a/bridging/ios/MCTiled2dMapZoomInfo.h
+++ b/bridging/ios/MCTiled2dMapZoomInfo.h
@@ -5,12 +5,21 @@
 
 @interface MCTiled2dMapZoomInfo : NSObject
 - (nonnull instancetype)initWithZoomLevelScaleFactor:(float)zoomLevelScaleFactor
-                               numDrawPreviousLayers:(int32_t)numDrawPreviousLayers;
+                               numDrawPreviousLayers:(int32_t)numDrawPreviousLayers
+                                  adaptScaleToScreen:(BOOL)adaptScaleToScreen;
 + (nonnull instancetype)tiled2dMapZoomInfoWithZoomLevelScaleFactor:(float)zoomLevelScaleFactor
-                                             numDrawPreviousLayers:(int32_t)numDrawPreviousLayers;
+                                             numDrawPreviousLayers:(int32_t)numDrawPreviousLayers
+                                                adaptScaleToScreen:(BOOL)adaptScaleToScreen;
 
+/** this factor is applied to the the scale */
 @property (nonatomic, readonly) float zoomLevelScaleFactor;
 
 @property (nonatomic, readonly) int32_t numDrawPreviousLayers;
+
+/**
+ * if this flag is set to true the map is scaled according to the wmts scaledenominator (https://gis.stackexchange.com/questions/315881/what-is-wmts-scaledenominator)
+ * and the screen ppi
+ */
+@property (nonatomic, readonly) BOOL adaptScaleToScreen;
 
 @end

--- a/bridging/ios/MCTiled2dMapZoomInfo.mm
+++ b/bridging/ios/MCTiled2dMapZoomInfo.mm
@@ -8,24 +8,28 @@
 
 - (nonnull instancetype)initWithZoomLevelScaleFactor:(float)zoomLevelScaleFactor
                                numDrawPreviousLayers:(int32_t)numDrawPreviousLayers
+                                  adaptScaleToScreen:(BOOL)adaptScaleToScreen
 {
     if (self = [super init]) {
         _zoomLevelScaleFactor = zoomLevelScaleFactor;
         _numDrawPreviousLayers = numDrawPreviousLayers;
+        _adaptScaleToScreen = adaptScaleToScreen;
     }
     return self;
 }
 
 + (nonnull instancetype)tiled2dMapZoomInfoWithZoomLevelScaleFactor:(float)zoomLevelScaleFactor
                                              numDrawPreviousLayers:(int32_t)numDrawPreviousLayers
+                                                adaptScaleToScreen:(BOOL)adaptScaleToScreen
 {
     return [(MCTiled2dMapZoomInfo*)[self alloc] initWithZoomLevelScaleFactor:zoomLevelScaleFactor
-                                                       numDrawPreviousLayers:numDrawPreviousLayers];
+                                                       numDrawPreviousLayers:numDrawPreviousLayers
+                                                          adaptScaleToScreen:adaptScaleToScreen];
 }
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@ %p zoomLevelScaleFactor:%@ numDrawPreviousLayers:%@>", self.class, (void *)self, @(self.zoomLevelScaleFactor), @(self.numDrawPreviousLayers)];
+    return [NSString stringWithFormat:@"<%@ %p zoomLevelScaleFactor:%@ numDrawPreviousLayers:%@ adaptScaleToScreen:%@>", self.class, (void *)self, @(self.zoomLevelScaleFactor), @(self.numDrawPreviousLayers), @(self.adaptScaleToScreen)];
 }
 
 @end

--- a/djinni/map/core.djinni
+++ b/djinni/map/core.djinni
@@ -130,6 +130,8 @@ map_camera_2d_interface = interface +c {
     get_visible_rect() : rect_coord;
     get_padding_adjusted_visible_rect() : rect_coord;
 
+    get_screen_density_ppi(): f32;
+
     # this method is called just before the update methods on all layers
     update();
 

--- a/djinni/map/layers/tiled/tiled_layer.djinni
+++ b/djinni/map/layers/tiled/tiled_layer.djinni
@@ -20,8 +20,12 @@ tiled_2d_map_zoom_level_info = record {
 }
 
 tiled_2d_map_zoom_info = record {
+    # this factor is applied to the the scale
 	zoom_level_scale_factor: f32;
 	num_draw_previous_layers: i32;
+    # if this flag is set to true the map is scaled according to the wmts scaledenominator (https://gis.stackexchange.com/questions/315881/what-is-wmts-scaledenominator)
+    # and the screen ppi
+    adapt_scale_to_screen: bool;
 }
 
 tiled_2d_map_source_interface = interface +c {

--- a/shared/public/MapCamera2dInterface.h
+++ b/shared/public/MapCamera2dInterface.h
@@ -64,6 +64,8 @@ public:
 
     virtual ::RectCoord getPaddingAdjustedVisibleRect() = 0;
 
+    virtual float getScreenDensityPpi() = 0;
+
     /** this method is called just before the update methods on all layers */
     virtual void update() = 0;
 

--- a/shared/public/Tiled2dMapSource.h
+++ b/shared/public/Tiled2dMapSource.h
@@ -40,7 +40,8 @@ template <class T, class L, class R> class Tiled2dMapSource :
     Tiled2dMapSource(const MapConfig &mapConfig, const std::shared_ptr<Tiled2dMapLayerConfig> &layerConfig,
                      const std::shared_ptr<CoordinateConversionHelperInterface> &conversionHelper,
                      const std::shared_ptr<SchedulerInterface> &scheduler,
-                     const std::shared_ptr<Tiled2dMapSourceListenerInterface> &listener);
+                     const std::shared_ptr<Tiled2dMapSourceListenerInterface> &listener,
+                     float screenDensityPpi);
 
     virtual void onVisibleBoundsChanged(const ::RectCoord &visibleBounds, double zoom) override;
 
@@ -87,6 +88,8 @@ template <class T, class L, class R> class Tiled2dMapSource :
 
 
     std::atomic<bool> isPaused;
+
+    float screenDensityPpi;
 
   private:
     void updateCurrentTileset(const ::RectCoord &visibleBounds, double zoom);

--- a/shared/public/Tiled2dMapSourceImpl.h
+++ b/shared/public/Tiled2dMapSourceImpl.h
@@ -69,7 +69,8 @@ template <class T, class L, class R> void Tiled2dMapSource<T, L, R>::updateCurre
 
     size_t numZoomLevels = zoomLevelInfos.size();
     int targetZoomLayer = -1;
-    const float screenScaleFactor = screenDensityPpi / (0.0254 / 0.00028); // Each pixel is assumed to be 0.28mm – https://gis.stackexchange.com/a/315989
+    // Each pixel is assumed to be 0.28mm – https://gis.stackexchange.com/a/315989
+    const float screenScaleFactor = zoomInfo.adaptScaleToScreen ? screenDensityPpi / (0.0254 / 0.00028) : 1.0;
     for (int i = 0; i < numZoomLevels; i++) {
         const Tiled2dMapZoomLevelInfo &zoomLevelInfo = zoomLevelInfos.at(i);
         if (zoomInfo.zoomLevelScaleFactor * screenScaleFactor * zoomLevelInfo.zoom < zoom) {

--- a/shared/public/Tiled2dMapZoomInfo.h
+++ b/shared/public/Tiled2dMapZoomInfo.h
@@ -7,12 +7,20 @@
 #include <utility>
 
 struct Tiled2dMapZoomInfo final {
+    /** this factor is applied to the the scale */
     float zoomLevelScaleFactor;
     int32_t numDrawPreviousLayers;
+    /**
+     * if this flag is set to true the map is scaled according to the wmts scaledenominator (https://gis.stackexchange.com/questions/315881/what-is-wmts-scaledenominator)
+     * and the screen ppi
+     */
+    bool adaptScaleToScreen;
 
     Tiled2dMapZoomInfo(float zoomLevelScaleFactor_,
-                       int32_t numDrawPreviousLayers_)
+                       int32_t numDrawPreviousLayers_,
+                       bool adaptScaleToScreen_)
     : zoomLevelScaleFactor(std::move(zoomLevelScaleFactor_))
     , numDrawPreviousLayers(std::move(numDrawPreviousLayers_))
+    , adaptScaleToScreen(std::move(adaptScaleToScreen_))
     {}
 };

--- a/shared/src/map/camera/MapCamera2d.cpp
+++ b/shared/src/map/camera/MapCamera2d.cpp
@@ -813,3 +813,8 @@ void MapCamera2d::setRotationEnabled(bool enabled) {
 void MapCamera2d::setSnapToNorthEnabled(bool enabled) {
     config.snapToNorthEnabled = enabled;
 }
+
+
+float MapCamera2d::getScreenDensityPpi() {
+    return screenDensityPpi;
+}

--- a/shared/src/map/camera/MapCamera2d.h
+++ b/shared/src/map/camera/MapCamera2d.h
@@ -120,6 +120,8 @@ class MapCamera2d : public MapCamera2dInterface,
 
     virtual void setSnapToNorthEnabled(bool enabled) override;
 
+    virtual float getScreenDensityPpi() override;
+
   protected:
     virtual void setupInertia();
 

--- a/shared/src/map/layers/tiled/raster/Tiled2dMapRasterLayer.cpp
+++ b/shared/src/map/layers/tiled/raster/Tiled2dMapRasterLayer.cpp
@@ -30,7 +30,10 @@ Tiled2dMapRasterLayer::Tiled2dMapRasterLayer(const std::shared_ptr<::Tiled2dMapL
 void Tiled2dMapRasterLayer::onAdded(const std::shared_ptr<::MapInterface> &mapInterface) {
     rasterSource = std::make_shared<Tiled2dMapRasterSource>(mapInterface->getMapConfig(), layerConfig,
                                                             mapInterface->getCoordinateConverterHelper(),
-                                                            mapInterface->getScheduler(), textureLoader, shared_from_this());
+                                                            mapInterface->getScheduler(),
+                                                            textureLoader,
+                                                            shared_from_this(),
+                                                            mapInterface->getCamera()->getScreenDensityPpi());
     setSourceInterface(rasterSource);
     Tiled2dMapLayer::onAdded(mapInterface);
 

--- a/shared/src/map/layers/tiled/raster/Tiled2dMapRasterSource.cpp
+++ b/shared/src/map/layers/tiled/raster/Tiled2dMapRasterSource.cpp
@@ -19,8 +19,9 @@ Tiled2dMapRasterSource::Tiled2dMapRasterSource(const MapConfig &mapConfig,
                                                const std::shared_ptr<CoordinateConversionHelperInterface> &conversionHelper,
                                                const std::shared_ptr<SchedulerInterface> &scheduler,
                                                const std::shared_ptr<::LoaderInterface> & textureLoader,
-                                               const std::shared_ptr<Tiled2dMapSourceListenerInterface> &listener)
-    : Tiled2dMapSource<TextureHolderInterface, TextureLoaderResult, std::shared_ptr<::TextureHolderInterface>>(mapConfig, layerConfig, conversionHelper, scheduler, listener)
+                                               const std::shared_ptr<Tiled2dMapSourceListenerInterface> &listener,
+                                               float screenDensityPpi)
+    : Tiled2dMapSource<TextureHolderInterface, TextureLoaderResult, std::shared_ptr<::TextureHolderInterface>>(mapConfig, layerConfig, conversionHelper, scheduler, listener, screenDensityPpi)
     , loader(textureLoader) {}
 
 TextureLoaderResult Tiled2dMapRasterSource::loadTile(Tiled2dMapTileInfo tile) {

--- a/shared/src/map/layers/tiled/raster/Tiled2dMapRasterSource.h
+++ b/shared/src/map/layers/tiled/raster/Tiled2dMapRasterSource.h
@@ -22,7 +22,8 @@ class Tiled2dMapRasterSource : public Tiled2dMapSource<TextureHolderInterface, T
                            const std::shared_ptr<CoordinateConversionHelperInterface> &conversionHelper,
                            const std::shared_ptr<SchedulerInterface> &scheduler,
                            const std::shared_ptr<::LoaderInterface> & textureLoader,
-                           const std::shared_ptr<Tiled2dMapSourceListenerInterface> &listener);
+                           const std::shared_ptr<Tiled2dMapSourceListenerInterface> &listener,
+                           float screenDensityPpi);
 
     std::unordered_set<Tiled2dMapRasterTileInfo> getCurrentTiles();
 

--- a/shared/src/map/layers/tiled/wmts/WmtsCapabilitiesResource.cpp
+++ b/shared/src/map/layers/tiled/wmts/WmtsCapabilitiesResource.cpp
@@ -44,7 +44,7 @@ public:
 
 
     std::shared_ptr<::Tiled2dMapLayerConfig> createLayerConfig(const std::string & identifier) override {
-        return createLayerConfigWithZoomInfo(identifier, Tiled2dMapZoomInfo(1.0, 0));
+        return createLayerConfigWithZoomInfo(identifier, Tiled2dMapZoomInfo(1.0, 0, true));
     };
 
     std::shared_ptr<::Tiled2dMapLayerConfig> createLayerConfigWithZoomInfo(const std::string & identifier, const ::Tiled2dMapZoomInfo & zoomInfo) override {


### PR DESCRIPTION
The WMTS Scale Denominator is defined with respect to a standardized rendering pixel of [0.28mm x 0.28mm.](https://gis.stackexchange.com/questions/315881/what-is-wmts-scaledenominator) Therefore when placing tiled layer this has to be taken into account.

What does this change:
Currently a Tiled2dMapRasterLayer was always rendered in the same size as if it was displayed on a ~90 ppi display. This almost always results in a blurry image since [all mobile devices](https://screensiz.es) have a much higher ppi.
Users of the SDK potentially have to change their zoomLevelScaleFactor to adapt to this change.
This can be enabled by setting the adaptScaleToScreen flag to true. Since this flag has to be set this is a breaking change to the API and users of the SDK have to explicitly set it and change their zoomLevelScaleFactor.