### PR TITLE
Fixes invalidate

### DIFF
--- a/shared/src/map/MapScene.cpp
+++ b/shared/src/map/MapScene.cpp
@@ -192,7 +192,7 @@ void MapScene::setViewportSize(const ::Vec2I &size) {
 void MapScene::setBackgroundColor(const Color &color) { getRenderingContext()->setBackgroundColor(color); }
 
 void MapScene::invalidate() {
-    if (!isInvalidated.test_and_set()) return;
+    if (isInvalidated.test_and_set()) return;
 
     if (auto handler = callbackHandler) {
         handler->invalidate();


### PR DESCRIPTION
- test_and_set() setzt auf true und gibt letzten Wert zurück, war dieser bereits "true", so muss nichts gemacht werden, war er false müssen die Handler benachrichtigt werden
- vor dem Fix wurde nur ab 2x invalidate und dann immer benachrichtigt