### PR TITLE
fixes masked line groups

### DIFF
--- a/ios/graphics/Model/Line/LineGroup2d.swift
+++ b/ios/graphics/Model/Line/LineGroup2d.swift
@@ -36,8 +36,8 @@ class LineGroup2d: BaseGraphicsObject {
         ss.stencilCompareFunction = .less
         ss.stencilFailureOperation = .keep
         ss.depthFailureOperation = .keep
-        ss.depthStencilPassOperation = .invert
-        ss.writeMask = 0b0111_1111
+        ss.depthStencilPassOperation = .zero
+        ss.writeMask = 0xFF
 
         let s = MTLDepthStencilDescriptor()
         s.frontFaceStencil = ss


### PR DESCRIPTION
Maske setzt erlaubte Region auf 1000_0000, Linie nimmt Referenz 0000_0001, falls kleiner darf gezeichnet werden (.less), danach darf dort nicht mehr gezeichnet werden, also auf .zero, dass 0000_0001 immer grösser.