### PR TITLE
Fixes getPaddingCorrectedBounds

### DIFF
--- a/shared/src/map/camera/MapCamera2d.cpp
+++ b/shared/src/map/camera/MapCamera2d.cpp
@@ -767,15 +767,17 @@ Coord MapCamera2d::adjustCoordForPadding(const Coord &coords, double targetZoom)
 RectCoord MapCamera2d::getPaddingCorrectedBounds() {
     double const factor = screenPixelAsRealMeterFactor * zoom;
 
-    Vec2D const padVec = Vec2D(0.5 * (paddingRight - paddingLeft) * factor, 0.5 * (paddingTop - paddingBottom) * factor);
+    double const addRight = (mapSystemRtl ? 1.0 : -1.0) * paddingRight * factor;
+    double const addLeft = (mapSystemRtl ? -1.0 : 1.0) * paddingLeft * factor;
+    double const addTop = (mapSystemTtb ? -1.0 : 1.0) * paddingTop * factor;
+    double const addBottom = (mapSystemTtb ? 1.0 : -1.0) * paddingBottom * factor;
 
-    Coord const topLeft(bounds.topLeft.systemIdentifier, bounds.topLeft.x + padVec.x, bounds.topLeft.y + padVec.y,
-                        bounds.topLeft.z);
+    // new top left and bottom right
+    const auto &id = bounds.topLeft.systemIdentifier;
+    Coord tl = Coord(id, bounds.topLeft.x + addLeft, bounds.topLeft.y + addTop, bounds.topLeft.z);
+    Coord br = Coord(id, bounds.bottomRight.x + addRight, bounds.bottomRight.y + addBottom, bounds.bottomRight.z);
 
-    Coord const bottomRight(bounds.bottomRight.systemIdentifier, bounds.bottomRight.x + padVec.x, bounds.bottomRight.y + padVec.y,
-                            bounds.bottomRight.z);
-
-    return RectCoord(topLeft, bottomRight);
+    return RectCoord(tl, br);
 }
 
 void MapCamera2d::clampCenterToPaddingCorrectedBounds() {


### PR DESCRIPTION
Padding was shared on both sides equally, now the correct padding is applied (even for right-to-left (bottom-to-top) systems).