### PR TITLE
fixes metal crash when attempting to load empty texture

### DIFF
--- a/ios/graphics/Texture/TextureHolder.swift
+++ b/ios/graphics/Texture/TextureHolder.swift
@@ -12,6 +12,10 @@ import Foundation
 import MapCoreSharedModule
 import MetalKit
 
+enum TextureHolderError: Error {
+    case emptyData
+}
+
 @objc
 public class TextureHolder: NSObject {
     let texture: MTLTexture
@@ -49,6 +53,9 @@ public class TextureHolder: NSObject {
     }
 
     public convenience init(_ data: Data, textureUsableSize: TextureUsableSize? = nil) throws {
+        guard !data.isEmpty else {
+            throw TextureHolderError.emptyData
+        }
         let options: [MTKTextureLoader.Option: Any] = [
             MTKTextureLoader.Option.SRGB: NSNumber(booleanLiteral: false),
         ]

--- a/ios/maps/MCTextureLoader.swift
+++ b/ios/maps/MCTextureLoader.swift
@@ -81,7 +81,12 @@ open class MCTextureLoader: MCLoaderInterface {
             return .init(data: nil, etag: response?.etag, status: .ERROR_OTHER, errorCode: (response?.statusCode).stringOrNil)
         }
 
-        guard let textureHolder = try? TextureHolder(data) else {
+        do {
+            let textureHolder = try TextureHolder(data)
+            return .init(data: textureHolder, etag: response?.etag, status: .OK, errorCode: nil)
+        } catch TextureHolderError.emptyData {
+            return .init(data: nil, etag: response?.etag, status: .OK, errorCode: nil)
+        } catch {
             // If metal can not load this image
             // try workaround to first load it into UIImage context
             guard let uiImage = UIImage(data: data) else {
@@ -100,7 +105,6 @@ open class MCTextureLoader: MCLoaderInterface {
 
             return .init(data: textureHolder, etag: response?.etag, status: .OK, errorCode: nil)
         }
-        return .init(data: textureHolder, etag: response?.etag, status: .OK, errorCode: nil)
     }
 
     open func loadData(_ url: String, etag: String?) -> MCDataLoaderResult {


### PR DESCRIPTION
Now the behavior is the same as on android.

Crash Stacktrace:
```
Crashed: com.apple.mtktextureloaderload
0  MetalKit                       0xd68c +[MTKTextureLoaderKTX isKTXFile:] + 28
1  MetalKit                       0x9fcc -[MTKTextureLoader _determineFileType:] + 40
2  MetalKit                       0xa380 -[MTKTextureLoader _loadData:options:uploader:label:completionHandler:] + 72
3  MetalKit                       0xa0d0 -[MTKTextureLoader _loadData:options:completionHandler:] + 164
4  MetalKit                       0x94a8 __65-[MTKTextureLoader newTextureWithData:options:completionHandler:]_block_invoke + 56
5  libdispatch.dylib              0x1e6c _dispatch_call_block_and_release + 32
6  libdispatch.dylib              0x3a30 _dispatch_client_callout + 20
7  libdispatch.dylib              0x6eec _dispatch_continuation_pop + 500
8  libdispatch.dylib              0x6558 _dispatch_async_redirect_invoke + 584
9  libdispatch.dylib              0x15164 _dispatch_root_queue_drain + 396
10 libdispatch.dylib              0x1596c _dispatch_worker_thread2 + 164
11 libsystem_pthread.dylib        0x1080 _pthread_wqthread + 228
12 libsystem_pthread.dylib        0xe5c start_wqthread + 8```