### PR TITLE
Tiled2dMapVectorLayer Functions

### DIFF
--- a/shared/public/Tiled2dMapVectorLayer.h
+++ b/shared/public/Tiled2dMapVectorLayer.h
@@ -67,6 +67,13 @@ public:
 protected:
     virtual std::shared_ptr<LayerInterface> getLayerForDescription(const std::shared_ptr<VectorLayerDescription> &layerDescription);
 
+    virtual std::shared_ptr<Tiled2dMapLayerConfig> getLayerConfig(const std::shared_ptr<VectorMapSourceDescription> &source);
+
+    void setMapDescription(const std::shared_ptr<VectorMapDescription> &mapDescription);
+
+    virtual void loadSpriteData();
+
+
     std::shared_ptr<Tiled2dMapVectorSource> vectorTileSource;
 
 private:
@@ -74,13 +81,9 @@ private:
 
     void loadStyleJson();
 
-    void setMapDescription(const std::shared_ptr<VectorMapDescription> &mapDescription);
-
     void initializeVectorLayer(const std::vector<std::shared_ptr<LayerInterface>> &newSublayers);
 
     virtual void updateMaskObjects(const std::unordered_map<Tiled2dMapTileInfo, Tiled2dMapLayerMaskWrapper> &toSetupMaskObject, const std::vector<const std::shared_ptr<MaskingObjectInterface>> &obsoleteMaskObjects);
-
-    void loadSpriteData();
 
     const std::optional<double> dpFactor;
 

--- a/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayer.cpp
+++ b/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayer.cpp
@@ -125,6 +125,11 @@ std::shared_ptr<LayerInterface> Tiled2dMapVectorLayer::getLayerForDescription(co
     return nullptr;
 }
 
+std::shared_ptr<Tiled2dMapLayerConfig>
+Tiled2dMapVectorLayer::getLayerConfig(const std::shared_ptr<VectorMapSourceDescription> &source) {
+    return std::make_shared<Tiled2dMapVectorLayerConfig>(source);
+}
+
 void Tiled2dMapVectorLayer::setMapDescription(const std::shared_ptr<VectorMapDescription> &mapDescription) {
     std::vector<std::shared_ptr<LayerInterface>> newSublayers;
     std::unordered_map<std::string, std::unordered_map<std::string, std::vector<std::shared_ptr<Tiled2dMapVectorSubLayer>>>> newSourceLayerMap;
@@ -163,7 +168,7 @@ void Tiled2dMapVectorLayer::setMapDescription(const std::shared_ptr<VectorMapDes
         this->layerConfigs.clear();
 
         for (auto const &source: mapDescription->vectorSources) {
-            layerConfigs[source->identifier] = std::make_shared<Tiled2dMapVectorLayerConfig>(source);
+            layerConfigs[source->identifier] = getLayerConfig(source);
         }
 
         initializeVectorLayer(newSublayers);


### PR DESCRIPTION
Expose multiple Tiled2dMapVectorLayer functions for subclasses, enable override of layer config creation