### PR TITLE
iOS: Graphics object race conditions

### DIFF
--- a/ios/graphics/Helpers/OSLock.swift
+++ b/ios/graphics/Helpers/OSLock.swift
@@ -34,7 +34,7 @@ public class OSLock {
         return try section()
     }
 
-    let oslock = {
+    private let oslock: UnsafeMutablePointer<os_unfair_lock_s> = {
         let lock = os_unfair_lock_t.allocate(capacity: 1)
         lock.initialize(to: os_unfair_lock_s())
         return lock

--- a/ios/graphics/Helpers/OSLock.swift
+++ b/ios/graphics/Helpers/OSLock.swift
@@ -1,0 +1,35 @@
+//
+//  OSLock.swift
+//  
+//
+//  Created by Stefan Mitterrutzner on 01.12.22.
+//
+
+import Foundation
+import os.lock
+
+// Wrapper around os_unfair_lock_t
+public class OSLock {
+    func lock() {
+        os_unfair_lock_lock(oslock)
+    }
+
+    func unlock() {
+        os_unfair_lock_unlock(oslock)
+    }
+
+    func trylock() -> Bool {
+        return os_unfair_lock_trylock(oslock)
+    }
+
+    let oslock = {
+        let lock1 = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
+        lock1.initialize(to: .init())
+        return lock1
+    }()
+
+    deinit {
+        oslock.deinitialize(count: 1)
+        oslock.deallocate()
+    }
+}

--- a/ios/graphics/Model/BaseGraphicsObject.swift
+++ b/ios/graphics/Model/BaseGraphicsObject.swift
@@ -24,6 +24,10 @@ open class BaseGraphicsObject {
 
     var isReadyFlag = false
 
+    // this lock is locked in the rendering cycle when accessing properties of graphics object
+    // therefore it has to be held for the shortest time possible
+    public let lock = OSLock()
+
     public init(device: MTLDevice, sampler: MTLSamplerState) {
         self.device = device
         self.sampler = sampler

--- a/ios/graphics/Model/Line/LineGroup2d.swift
+++ b/ios/graphics/Model/Line/LineGroup2d.swift
@@ -125,14 +125,12 @@ extension LineGroup2d: MCLineGroup2dInterface {
     func setLines(_ lines: MCSharedBytes, indices: MCSharedBytes) {
         guard lines.elementCount != 0 else {
 
-            lock.lock()
-            defer {
-                lock.unlock()
+            lock.withCritical {
+                lineVerticesBuffer = nil
+                lineIndicesBuffer = nil
+                indicesCount = 0
             }
 
-            lineVerticesBuffer = nil
-            lineIndicesBuffer = nil
-            indicesCount = 0
             return
         }
         guard let verticesBuffer = device.makeBuffer(from: lines),
@@ -144,15 +142,11 @@ extension LineGroup2d: MCLineGroup2dInterface {
         verticesBuffer.label = "LineGroup2d.verticesBuffer"
         indicesBuffer.label = "LineGroup2d.indicesBuffer"
 
-
-        lock.lock()
-        defer {
-            lock.unlock()
+        lock.withCritical {
+            indicesCount = Int(indices.elementCount)
+            lineVerticesBuffer = verticesBuffer
+            lineIndicesBuffer = indicesBuffer
         }
-
-        indicesCount = Int(indices.elementCount)
-        lineVerticesBuffer = verticesBuffer
-        lineIndicesBuffer = indicesBuffer
     }
 
     func asGraphicsObject() -> MCGraphicsObjectInterface? {

--- a/ios/graphics/Model/Line/LineGroup2d.swift
+++ b/ios/graphics/Model/Line/LineGroup2d.swift
@@ -68,6 +68,11 @@ final class LineGroup2d: BaseGraphicsObject {
                          mvpMatrix: Int64,
                          isMasked: Bool,
                          screenPixelAsRealMeterFactor: Double) {
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+
         guard let lineVerticesBuffer = lineVerticesBuffer,
               let lineIndicesBuffer = lineIndicesBuffer
         else { return }
@@ -78,6 +83,7 @@ final class LineGroup2d: BaseGraphicsObject {
             encoder.popDebugGroup()
         }
         #endif
+
 
         if stencilState == nil {
             setupStencilBufferDescriptor()
@@ -118,6 +124,12 @@ final class LineGroup2d: BaseGraphicsObject {
 extension LineGroup2d: MCLineGroup2dInterface {
     func setLines(_ lines: MCSharedBytes, indices: MCSharedBytes) {
         guard lines.elementCount != 0 else {
+
+            lock.lock()
+            defer {
+                lock.unlock()
+            }
+
             lineVerticesBuffer = nil
             lineIndicesBuffer = nil
             indicesCount = 0
@@ -131,6 +143,12 @@ extension LineGroup2d: MCLineGroup2dInterface {
 
         verticesBuffer.label = "LineGroup2d.verticesBuffer"
         indicesBuffer.label = "LineGroup2d.indicesBuffer"
+
+
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
 
         indicesCount = Int(indices.elementCount)
         lineVerticesBuffer = verticesBuffer

--- a/ios/graphics/Model/Polygon/Polygon2d.swift
+++ b/ios/graphics/Model/Polygon/Polygon2d.swift
@@ -33,6 +33,11 @@ final class Polygon2d: BaseGraphicsObject {
                          mvpMatrix: Int64,
                          isMasked: Bool,
                          screenPixelAsRealMeterFactor _: Double) {
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+        
         guard let verticesBuffer = verticesBuffer,
               let indicesBuffer = indicesBuffer else { return }
 
@@ -97,6 +102,11 @@ extension Polygon2d: MCMaskingObjectInterface {
               let context = context as? RenderingContext,
               let encoder = context.encoder else { return }
 
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+
         guard let verticesBuffer = verticesBuffer,
               let indicesBuffer = indicesBuffer
         else { return }
@@ -134,6 +144,11 @@ extension Polygon2d: MCMaskingObjectInterface {
 extension Polygon2d: MCPolygon2dInterface {
     func setVertices(_ vertices: [MCVec2D], indices: [NSNumber]) {
         guard !vertices.isEmpty, !indices.isEmpty else {
+            lock.lock()
+            defer {
+                lock.unlock()
+            }
+
             indicesCount = 0
             verticesBuffer = nil
             indicesBuffer = nil
@@ -149,6 +164,10 @@ extension Polygon2d: MCPolygon2dInterface {
               let indicesBuffer = device.makeBuffer(bytes: indices, length: MemoryLayout<UInt16>.stride * indices.count, options: [])
         else {
             fatalError("Cannot allocate buffers for the UBTileModel")
+        }
+        lock.lock()
+        defer {
+            lock.unlock()
         }
 
         indicesCount = indices.count

--- a/ios/graphics/Model/Polygon/Polygon2d.swift
+++ b/ios/graphics/Model/Polygon/Polygon2d.swift
@@ -144,14 +144,11 @@ extension Polygon2d: MCMaskingObjectInterface {
 extension Polygon2d: MCPolygon2dInterface {
     func setVertices(_ vertices: [MCVec2D], indices: [NSNumber]) {
         guard !vertices.isEmpty, !indices.isEmpty else {
-            lock.lock()
-            defer {
-                lock.unlock()
+            lock.withCritical {
+                indicesCount = 0
+                verticesBuffer = nil
+                indicesBuffer = nil
             }
-
-            indicesCount = 0
-            verticesBuffer = nil
-            indicesBuffer = nil
             return
         }
 
@@ -165,14 +162,12 @@ extension Polygon2d: MCPolygon2dInterface {
         else {
             fatalError("Cannot allocate buffers for the UBTileModel")
         }
-        lock.lock()
-        defer {
-            lock.unlock()
-        }
 
-        indicesCount = indices.count
-        self.verticesBuffer = verticesBuffer
-        self.indicesBuffer = indicesBuffer
+        lock.withCritical {
+            indicesCount = indices.count
+            self.verticesBuffer = verticesBuffer
+            self.indicesBuffer = indicesBuffer
+        }
     }
 
     func asGraphicsObject() -> MCGraphicsObjectInterface? { self }

--- a/ios/graphics/Model/Polygon/PolygonGroup2d.swift
+++ b/ios/graphics/Model/Polygon/PolygonGroup2d.swift
@@ -95,13 +95,11 @@ final class PolygonGroup2d: BaseGraphicsObject {
 extension PolygonGroup2d: MCPolygonGroup2dInterface {
     func setVertices(_ vertices: MCSharedBytes, indices: MCSharedBytes) {
         guard vertices.elementCount > 0 else {
-            lock.lock()
-            defer {
-                lock.unlock()
+            lock.withCritical {
+                self.indicesCount = 0
+                verticesBuffer = nil
+                indicesBuffer = nil
             }
-            self.indicesCount = 0
-            verticesBuffer = nil
-            indicesBuffer = nil
             return
         }
 
@@ -110,13 +108,11 @@ extension PolygonGroup2d: MCPolygonGroup2dInterface {
         else {
             fatalError("Cannot allocate buffers for the UBTileModel")
         }
-        lock.lock()
-        defer {
-            lock.unlock()
+        lock.withCritical {
+            self.indicesCount = Int(indices.elementCount)
+            self.verticesBuffer = verticesBuffer
+            self.indicesBuffer = indicesBuffer
         }
-        self.indicesCount = Int(indices.elementCount)
-        self.verticesBuffer = verticesBuffer
-        self.indicesBuffer = indicesBuffer
     }
 
     func asGraphicsObject() -> MCGraphicsObjectInterface? { self }

--- a/ios/graphics/Model/Polygon/PolygonGroup2d.swift
+++ b/ios/graphics/Model/Polygon/PolygonGroup2d.swift
@@ -52,6 +52,11 @@ final class PolygonGroup2d: BaseGraphicsObject {
                          mvpMatrix: Int64,
                          isMasked: Bool,
                          screenPixelAsRealMeterFactor _: Double) {
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+
         guard let verticesBuffer = verticesBuffer,
               let indicesBuffer = indicesBuffer else { return }
 
@@ -90,6 +95,10 @@ final class PolygonGroup2d: BaseGraphicsObject {
 extension PolygonGroup2d: MCPolygonGroup2dInterface {
     func setVertices(_ vertices: MCSharedBytes, indices: MCSharedBytes) {
         guard vertices.elementCount > 0 else {
+            lock.lock()
+            defer {
+                lock.unlock()
+            }
             self.indicesCount = 0
             verticesBuffer = nil
             indicesBuffer = nil
@@ -101,7 +110,10 @@ extension PolygonGroup2d: MCPolygonGroup2dInterface {
         else {
             fatalError("Cannot allocate buffers for the UBTileModel")
         }
-
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
         self.indicesCount = Int(indices.elementCount)
         self.verticesBuffer = verticesBuffer
         self.indicesBuffer = indicesBuffer

--- a/ios/graphics/Model/Quad2d.swift
+++ b/ios/graphics/Model/Quad2d.swift
@@ -71,6 +71,12 @@ final class Quad2d: BaseGraphicsObject {
               let verticesBuffer = verticesBuffer,
               let indicesBuffer = indicesBuffer else { return }
 
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+
+
         if shader is AlphaShader, texture == nil {
             ready = false
             return
@@ -163,6 +169,11 @@ extension Quad2d: MCQuad2dInterface {
 
         guard let verticesBuffer = device.makeBuffer(bytes: vertecies, length: MemoryLayout<Vertex>.stride * vertecies.count, options: []), let indicesBuffer = device.makeBuffer(bytes: indices, length: MemoryLayout<UInt16>.stride * indices.count, options: []) else {
             fatalError("Cannot allocate buffers")
+        }
+
+        lock.lock()
+        defer {
+            lock.unlock()
         }
 
         indicesCount = indices.count

--- a/ios/graphics/Model/Quad2d.swift
+++ b/ios/graphics/Model/Quad2d.swift
@@ -171,14 +171,11 @@ extension Quad2d: MCQuad2dInterface {
             fatalError("Cannot allocate buffers")
         }
 
-        lock.lock()
-        defer {
-            lock.unlock()
+        lock.withCritical {
+            indicesCount = indices.count
+            self.verticesBuffer = verticesBuffer
+            self.indicesBuffer = indicesBuffer
         }
-
-        indicesCount = indices.count
-        self.verticesBuffer = verticesBuffer
-        self.indicesBuffer = indicesBuffer
     }
 
     func loadTexture(_ context: MCRenderingContextInterface?, textureHolder: MCTextureHolderInterface?) {

--- a/ios/graphics/Model/Text/Text.swift
+++ b/ios/graphics/Model/Text/Text.swift
@@ -138,28 +138,22 @@ extension Text: MCTextInterface {
         }
 
         guard !vertices.isEmpty else {
-            lock.lock()
-            defer {
-                lock.unlock()
+            lock.withCritical {
+                indicesCount = 0
+                self.verticesBuffer = nil
+                self.indicesBuffer = nil
             }
-
-            indicesCount = 0
-            self.verticesBuffer = nil
-            self.indicesBuffer = nil
             return
         }
 
         guard let verticesBuffer = device.makeBuffer(bytes: vertices, length: MemoryLayout<Vertex>.stride * vertices.count, options: []), let indicesBuffer = device.makeBuffer(bytes: indices, length: MemoryLayout<UInt16>.stride * indices.count, options: []) else {
             fatalError("Cannot allocate buffers")
         }
-        lock.lock()
-        defer {
-            lock.unlock()
+        lock.withCritical {
+            indicesCount = indices.count
+            self.verticesBuffer = verticesBuffer
+            self.indicesBuffer = indicesBuffer
         }
-
-        indicesCount = indices.count
-        self.verticesBuffer = verticesBuffer
-        self.indicesBuffer = indicesBuffer
     }
 
     func loadTexture(_ context: MCRenderingContextInterface?, textureHolder: MCTextureHolderInterface?) {

--- a/ios/graphics/Model/Text/Text.swift
+++ b/ios/graphics/Model/Text/Text.swift
@@ -51,6 +51,11 @@ final class Text: BaseGraphicsObject {
                          mvpMatrix: Int64,
                          isMasked: Bool,
                          screenPixelAsRealMeterFactor _: Double) {
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+
         guard let verticesBuffer = verticesBuffer,
               let indicesBuffer = indicesBuffer else { return }
 
@@ -133,11 +138,23 @@ extension Text: MCTextInterface {
         }
 
         guard !vertices.isEmpty else {
+            lock.lock()
+            defer {
+                lock.unlock()
+            }
+
+            indicesCount = 0
+            self.verticesBuffer = nil
+            self.indicesBuffer = nil
             return
         }
 
         guard let verticesBuffer = device.makeBuffer(bytes: vertices, length: MemoryLayout<Vertex>.stride * vertices.count, options: []), let indicesBuffer = device.makeBuffer(bytes: indices, length: MemoryLayout<UInt16>.stride * indices.count, options: []) else {
             fatalError("Cannot allocate buffers")
+        }
+        lock.lock()
+        defer {
+            lock.unlock()
         }
 
         indicesCount = indices.count


### PR DESCRIPTION
Currently a race condition can happen if the properties of a graphics object are updated while the object is being rendered.
If an object is updated very frequently there is a good chance this happens. Therefore I introduced the concept of locking in iOS graphics objects.
The locking mechanism used is [os_unfair_lock](https://developer.apple.com/documentation/os/1646466-os_unfair_lock_lock) since it is the faster mechanism on iOS according to: https://serhiybutz.medium.com/swift-mutex-benchmark-b21ee293d9ad