### PR TITLE
Fix TouchHandler Listenes Indices

### DIFF
--- a/bridging/android/java/io/openmobilemaps/mapscore/shared/map/LayerInterface.kt
+++ b/bridging/android/java/io/openmobilemaps/mapscore/shared/map/LayerInterface.kt
@@ -13,7 +13,7 @@ abstract class LayerInterface {
 
     abstract fun buildRenderPasses(): ArrayList<io.openmobilemaps.mapscore.shared.graphics.RenderPassInterface>
 
-    abstract fun onAdded(mapInterface: MapInterface)
+    abstract fun onAdded(mapInterface: MapInterface, layerIndex: Int)
 
     abstract fun onRemoved()
 
@@ -76,11 +76,11 @@ abstract class LayerInterface {
         }
         private external fun native_buildRenderPasses(_nativeRef: Long): ArrayList<io.openmobilemaps.mapscore.shared.graphics.RenderPassInterface>
 
-        override fun onAdded(mapInterface: MapInterface) {
+        override fun onAdded(mapInterface: MapInterface, layerIndex: Int) {
             assert(!this.destroyed.get()) { error("trying to use a destroyed object") }
-            native_onAdded(this.nativeRef, mapInterface)
+            native_onAdded(this.nativeRef, mapInterface, layerIndex)
         }
-        private external fun native_onAdded(_nativeRef: Long, mapInterface: MapInterface)
+        private external fun native_onAdded(_nativeRef: Long, mapInterface: MapInterface, layerIndex: Int)
 
         override fun onRemoved() {
             assert(!this.destroyed.get()) { error("trying to use a destroyed object") }

--- a/bridging/android/jni/map/NativeLayerInterface.cpp
+++ b/bridging/android/jni/map/NativeLayerInterface.cpp
@@ -43,12 +43,13 @@ std::vector<std::shared_ptr<::RenderPassInterface>> NativeLayerInterface::JavaPr
     ::djinni::jniExceptionCheck(jniEnv);
     return ::djinni::List<::djinni_generated::NativeRenderPassInterface>::toCpp(jniEnv, jret);
 }
-void NativeLayerInterface::JavaProxy::onAdded(const std::shared_ptr<::MapInterface> & c_mapInterface) {
+void NativeLayerInterface::JavaProxy::onAdded(const std::shared_ptr<::MapInterface> & c_mapInterface, int32_t c_layerIndex) {
     auto jniEnv = ::djinni::jniGetThreadEnv();
     ::djinni::JniLocalScope jscope(jniEnv, 10);
     const auto& data = ::djinni::JniClass<::djinni_generated::NativeLayerInterface>::get();
     jniEnv->CallVoidMethod(Handle::get().get(), data.method_onAdded,
-                           ::djinni::get(::djinni_generated::NativeMapInterface::fromCpp(jniEnv, c_mapInterface)));
+                           ::djinni::get(::djinni_generated::NativeMapInterface::fromCpp(jniEnv, c_mapInterface)),
+                           ::djinni::get(::djinni::I32::fromCpp(jniEnv, c_layerIndex)));
     ::djinni::jniExceptionCheck(jniEnv);
 }
 void NativeLayerInterface::JavaProxy::onRemoved() {
@@ -178,12 +179,13 @@ CJNIEXPORT jobject JNICALL Java_io_openmobilemaps_mapscore_shared_map_LayerInter
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 
-CJNIEXPORT void JNICALL Java_io_openmobilemaps_mapscore_shared_map_LayerInterface_00024CppProxy_native_1onAdded(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jobject j_mapInterface)
+CJNIEXPORT void JNICALL Java_io_openmobilemaps_mapscore_shared_map_LayerInterface_00024CppProxy_native_1onAdded(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jobject j_mapInterface, jint j_layerIndex)
 {
     try {
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::LayerInterface>(nativeRef);
-        ref->onAdded(::djinni_generated::NativeMapInterface::toCpp(jniEnv, j_mapInterface));
+        ref->onAdded(::djinni_generated::NativeMapInterface::toCpp(jniEnv, j_mapInterface),
+                     ::djinni::I32::toCpp(jniEnv, j_layerIndex));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 

--- a/bridging/android/jni/map/NativeLayerInterface.h
+++ b/bridging/android/jni/map/NativeLayerInterface.h
@@ -36,7 +36,7 @@ private:
         void setMaskingObject(const std::shared_ptr<::MaskingObjectInterface> & maskingObject) override;
         void update() override;
         std::vector<std::shared_ptr<::RenderPassInterface>> buildRenderPasses() override;
-        void onAdded(const std::shared_ptr<::MapInterface> & mapInterface) override;
+        void onAdded(const std::shared_ptr<::MapInterface> & mapInterface, int32_t layerIndex) override;
         void onRemoved() override;
         void pause() override;
         void resume() override;
@@ -58,7 +58,7 @@ private:
     const jmethodID method_setMaskingObject { ::djinni::jniGetMethodID(clazz.get(), "setMaskingObject", "(Lio/openmobilemaps/mapscore/shared/graphics/objects/MaskingObjectInterface;)V") };
     const jmethodID method_update { ::djinni::jniGetMethodID(clazz.get(), "update", "()V") };
     const jmethodID method_buildRenderPasses { ::djinni::jniGetMethodID(clazz.get(), "buildRenderPasses", "()Ljava/util/ArrayList;") };
-    const jmethodID method_onAdded { ::djinni::jniGetMethodID(clazz.get(), "onAdded", "(Lio/openmobilemaps/mapscore/shared/map/MapInterface;)V") };
+    const jmethodID method_onAdded { ::djinni::jniGetMethodID(clazz.get(), "onAdded", "(Lio/openmobilemaps/mapscore/shared/map/MapInterface;I)V") };
     const jmethodID method_onRemoved { ::djinni::jniGetMethodID(clazz.get(), "onRemoved", "()V") };
     const jmethodID method_pause { ::djinni::jniGetMethodID(clazz.get(), "pause", "()V") };
     const jmethodID method_resume { ::djinni::jniGetMethodID(clazz.get(), "resume", "()V") };

--- a/bridging/ios/MCLayerInterface+Private.mm
+++ b/bridging/ios/MCLayerInterface+Private.mm
@@ -56,9 +56,11 @@ static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for th
     } DJINNI_TRANSLATE_EXCEPTIONS()
 }
 
-- (void)onAdded:(nullable MCMapInterface *)mapInterface {
+- (void)onAdded:(nullable MCMapInterface *)mapInterface
+     layerIndex:(int32_t)layerIndex {
     try {
-        _cppRefHandle.get()->onAdded(::djinni_generated::MapInterface::toCpp(mapInterface));
+        _cppRefHandle.get()->onAdded(::djinni_generated::MapInterface::toCpp(mapInterface),
+                                     ::djinni::I32::toCpp(layerIndex));
     } DJINNI_TRANSLATE_EXCEPTIONS()
 }
 
@@ -164,10 +166,11 @@ public:
             return ::djinni::List<::djinni_generated::RenderPassInterface>::toCpp(objcpp_result_);
         }
     }
-    void onAdded(const std::shared_ptr<::MapInterface> & c_mapInterface) override
+    void onAdded(const std::shared_ptr<::MapInterface> & c_mapInterface, int32_t c_layerIndex) override
     {
         @autoreleasepool {
-            [djinni_private_get_proxied_objc_object() onAdded:(::djinni_generated::MapInterface::fromCpp(c_mapInterface))];
+            [djinni_private_get_proxied_objc_object() onAdded:(::djinni_generated::MapInterface::fromCpp(c_mapInterface))
+                                                   layerIndex:(::djinni::I32::fromCpp(c_layerIndex))];
         }
     }
     void onRemoved() override

--- a/bridging/ios/MCLayerInterface.h
+++ b/bridging/ios/MCLayerInterface.h
@@ -18,7 +18,8 @@
 
 - (nonnull NSArray<id<MCRenderPassInterface>> *)buildRenderPasses;
 
-- (void)onAdded:(nullable MCMapInterface *)mapInterface;
+- (void)onAdded:(nullable MCMapInterface *)mapInterface
+     layerIndex:(int32_t)layerIndex;
 
 - (void)onRemoved;
 

--- a/djinni/map/core.djinni
+++ b/djinni/map/core.djinni
@@ -85,7 +85,7 @@ layer_interface = interface +c +j +o {
     set_masking_object(masking_object: optional<masking_object_interface>);
     update();
     build_render_passes(): list<render_pass_interface>;
-    onAdded(map_interface: map_interface);
+    onAdded(map_interface: map_interface, layer_index: i32);
     onRemoved();
     pause();
     resume();

--- a/shared/public/LayerInterface.h
+++ b/shared/public/LayerInterface.h
@@ -7,6 +7,7 @@
 #include "MaskingObjectInterface.h"
 #include "RectI.h"
 #include "RenderPassInterface.h"
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <vector>
@@ -24,7 +25,7 @@ public:
 
     virtual std::vector<std::shared_ptr<::RenderPassInterface>> buildRenderPasses() = 0;
 
-    virtual void onAdded(const std::shared_ptr<MapInterface> & mapInterface) = 0;
+    virtual void onAdded(const std::shared_ptr<MapInterface> & mapInterface, int32_t layerIndex) = 0;
 
     virtual void onRemoved() = 0;
 

--- a/shared/public/LineHelper.h
+++ b/shared/public/LineHelper.h
@@ -19,7 +19,7 @@ class LineHelper {
                             const Coord &point,
                             double pointSystemDistance,
                             const std::shared_ptr<CoordinateConversionHelperInterface> &conversionHelper) {
-        LineHelper::pointWithin(line->getCoordinates(), point, pointSystemDistance, conversionHelper);
+        return LineHelper::pointWithin(line->getCoordinates(), point, pointSystemDistance, conversionHelper);
     }
 
     static bool pointWithin(const std::vector<::Coord> &coordinates,

--- a/shared/public/LineLayer.h
+++ b/shared/public/LineLayer.h
@@ -59,7 +59,7 @@ class LineLayer : public LineLayerInterface,
 
     virtual std::vector<std::shared_ptr<::RenderPassInterface>> buildRenderPasses() override;
 
-    virtual void onAdded(const std::shared_ptr<MapInterface> &mapInterface) override;
+    virtual void onAdded(const std::shared_ptr<MapInterface> &mapInterface, int32_t layerIndex) override;
 
     virtual void onRemoved() override;
 

--- a/shared/public/PolygonLayer.h
+++ b/shared/public/PolygonLayer.h
@@ -59,7 +59,7 @@ class PolygonLayer : public PolygonLayerInterface,
 
     virtual std::vector<std::shared_ptr<::RenderPassInterface>> buildRenderPasses() override;
 
-    virtual void onAdded(const std::shared_ptr<MapInterface> &mapInterface) override;
+    virtual void onAdded(const std::shared_ptr<MapInterface> &mapInterface, int32_t layerIndex) override;
 
     virtual void onRemoved() override;
 

--- a/shared/public/SimpleLayerInterface.h
+++ b/shared/public/SimpleLayerInterface.h
@@ -23,7 +23,7 @@ class SimpleLayerInterface : public LayerInterface {
         return {};
     };
 
-    virtual void onAdded(const std::shared_ptr<MapInterface> & mapInterface) {};
+    virtual void onAdded(const std::shared_ptr<MapInterface> & mapInterface, int32_t layerIndex) {};
 
     virtual void onRemoved() {};
 

--- a/shared/public/TextLayer.h
+++ b/shared/public/TextLayer.h
@@ -42,7 +42,7 @@ class TextLayer : public TextLayerInterface, public SimpleLayerInterface, public
 
     virtual std::vector<std::shared_ptr<::RenderPassInterface>> buildRenderPasses();
 
-    virtual void onAdded(const std::shared_ptr<MapInterface> &mapInterface);
+    virtual void onAdded(const std::shared_ptr<MapInterface> &mapInterface, int32_t layerIndex);
 
     virtual void onRemoved();
 

--- a/shared/public/Tiled2dMapLayer.h
+++ b/shared/public/Tiled2dMapLayer.h
@@ -22,7 +22,6 @@
 class Tiled2dMapLayer : public SimpleLayerInterface,
                         public Tiled2dMapSourceListenerInterface,
                         public MapCamera2dListenerInterface,
-                        public SimpleTouchInterface,
                         public std::enable_shared_from_this<Tiled2dMapLayer> {
   public:
     Tiled2dMapLayer();
@@ -33,7 +32,7 @@ class Tiled2dMapLayer : public SimpleLayerInterface,
 
     virtual std::vector<std::shared_ptr<::RenderPassInterface>> buildRenderPasses() override = 0;
 
-    virtual void onAdded(const std::shared_ptr<::MapInterface> &mapInterface) override;
+    virtual void onAdded(const std::shared_ptr<::MapInterface> &mapInterface, int32_t layerIndex) override;
 
     virtual void onRemoved() override;
 

--- a/shared/public/Tiled2dMapRasterLayer.h
+++ b/shared/public/Tiled2dMapRasterLayer.h
@@ -26,20 +26,25 @@
 #include <atomic>
 
 
-class Tiled2dMapRasterLayer : public Tiled2dMapLayer, public Tiled2dMapRasterLayerInterface {
+class Tiled2dMapRasterLayer : public Tiled2dMapLayer,
+                              public SimpleTouchInterface,
+                              public Tiled2dMapRasterLayerInterface {
 public:
     Tiled2dMapRasterLayer(const std::shared_ptr<::Tiled2dMapLayerConfig> &layerConfig,
-                          const std::vector<std::shared_ptr<::LoaderInterface>> & tileLoaders);
+                          const std::vector<std::shared_ptr<::LoaderInterface>> & tileLoaders,
+                          bool registerToTouchHandler = true);
 
     Tiled2dMapRasterLayer(const std::shared_ptr<::Tiled2dMapLayerConfig> &layerConfig,
                           const std::vector<std::shared_ptr<::LoaderInterface>> & tileLoaders,
-                          const std::shared_ptr<::MaskingObjectInterface> &mask);
+                          const std::shared_ptr<::MaskingObjectInterface> &mask,
+                          bool registerToTouchHandler = true);
 
     Tiled2dMapRasterLayer(const std::shared_ptr<::Tiled2dMapLayerConfig> &layerConfig,
                           const std::vector<std::shared_ptr<::LoaderInterface>> &tileLoader,
-                          const std::shared_ptr<::ShaderProgramInterface> &shader);
+                          const std::shared_ptr<::ShaderProgramInterface> &shader,
+                          bool registerToTouchHandler = true);
 
-    virtual void onAdded(const std::shared_ptr<::MapInterface> &mapInterface) override;
+    virtual void onAdded(const std::shared_ptr<::MapInterface> &mapInterface, int32_t layerIndex) override;
 
     virtual void onRemoved() override;
 
@@ -122,4 +127,5 @@ protected:
 
     float alpha;
     bool animationsEnabled = true;
+    bool registerToTouchHandler = true;
 };

--- a/shared/public/Tiled2dMapVectorLayer.h
+++ b/shared/public/Tiled2dMapVectorLayer.h
@@ -22,7 +22,7 @@
 #include "Tiled2dMapVectorLayerSelectionInterface.h"
 #include "TiledLayerError.h"
 
-class Tiled2dMapVectorLayer : public Tiled2dMapLayer, public Tiled2dMapVectorLayerInterface, public Tiled2dMapVectorLayerReadyInterface {
+class Tiled2dMapVectorLayer : public Tiled2dMapLayer, public TouchInterface, public Tiled2dMapVectorLayerInterface, public Tiled2dMapVectorLayerReadyInterface {
 public:
     Tiled2dMapVectorLayer(const std::string &layerName,
                           const std::string &remoteStyleJsonUrl,
@@ -52,7 +52,7 @@ public:
 
     virtual std::vector<std::shared_ptr<::RenderPassInterface>> buildRenderPasses() override;
 
-    virtual void onAdded(const std::shared_ptr<::MapInterface> &mapInterface) override;
+    virtual void onAdded(const std::shared_ptr<::MapInterface> &mapInterface, int32_t layerIndex) override;
 
     virtual void onRemoved() override;
 
@@ -81,6 +81,30 @@ public:
     void updateLayerDescription(std::shared_ptr<VectorLayerDescription> layerDescription);
 
     std::optional<FeatureContext> getFeatureContext(int64_t identifier);
+
+    // Touch Interface
+    bool onTouchDown(const Vec2F &posScreen) override;
+
+    bool onClickUnconfirmed(const Vec2F &posScreen) override;
+
+    bool onClickConfirmed(const Vec2F &posScreen) override;
+
+    bool onDoubleClick(const Vec2F &posScreen) override;
+
+    bool onLongPress(const Vec2F &posScreen) override;
+
+    bool onMove(const Vec2F &deltaScreen, bool confirmed, bool doubleClick) override;
+
+    bool onMoveComplete() override;
+
+    bool onTwoFingerClick(const Vec2F &posScreen1, const Vec2F &posScreen2) override;
+
+    bool onTwoFingerMove(const std::vector<::Vec2F> &posScreenOld, const std::vector<::Vec2F> &posScreenNew) override;
+
+    bool onTwoFingerMoveComplete() override;
+
+    void clearTouch() override;
+
 protected:
     virtual std::shared_ptr<LayerInterface> getLayerForDescription(const std::shared_ptr<VectorLayerDescription> &layerDescription);
 
@@ -106,6 +130,8 @@ private:
     void initializeVectorLayer(const std::vector<std::shared_ptr<LayerInterface>> &newSublayers);
 
     virtual void updateMaskObjects(const std::unordered_map<Tiled2dMapTileInfo, Tiled2dMapLayerMaskWrapper> &toSetupMaskObject, const std::vector<const std::shared_ptr<MaskingObjectInterface>> &obsoleteMaskObjects);
+
+    int32_t layerIndex = -1;
 
     const std::optional<double> dpFactor;
 

--- a/shared/public/Tiled2dMapVectorSubLayer.h
+++ b/shared/public/Tiled2dMapVectorSubLayer.h
@@ -30,7 +30,7 @@ public:
 
     virtual std::vector<std::shared_ptr<RenderPassInterface>> buildRenderPasses(const std::unordered_set<Tiled2dMapTileInfo> &tiles);
 
-    virtual void onAdded(const std::shared_ptr<MapInterface> &mapInterface) override;
+    virtual void onAdded(const std::shared_ptr<MapInterface> &mapInterface, int32_t layerIndex) override;
 
     virtual void onRemoved() override;
 

--- a/shared/src/map/controls/DefaultTouchHandler.h
+++ b/shared/src/map/controls/DefaultTouchHandler.h
@@ -13,11 +13,13 @@
 #include "SchedulerInterface.h"
 #include "TouchHandlerInterface.h"
 #include "Vec2F.h"
+#include <list>
 #include <map>
+#include <mutex>
 
 class DefaultTouchHandler : public TouchHandlerInterface {
 
-  public:
+public:
     DefaultTouchHandler(const std::shared_ptr<SchedulerInterface> SchedulerInterface, float density);
 
     virtual void onTouchEvent(const TouchEvent &touchEvent) override;
@@ -28,7 +30,12 @@ class DefaultTouchHandler : public TouchHandlerInterface {
 
     virtual void insertListener(const std::shared_ptr<TouchInterface> &listener, int32_t index) override;
 
-  private:
+private:
+    struct ListenerEntry {
+        int32_t index;
+        std::shared_ptr<TouchInterface> listener;
+    };
+
     enum TouchHandlingState {
         IDLE,
         ONE_FINGER_DOWN,
@@ -66,7 +73,8 @@ class DefaultTouchHandler : public TouchHandlerInterface {
     float density;
     float clickDistancePx;
 
-    std::map<int, std::shared_ptr<TouchInterface>, std::greater<int>> listeners;
+    std::recursive_mutex listenerMutex;
+    std::list<ListenerEntry> listeners; // ordered by the decreasing index
 
     const std::shared_ptr<SchedulerInterface> scheduler;
 

--- a/shared/src/map/layers/icon/IconLayer.cpp
+++ b/shared/src/map/layers/icon/IconLayer.cpp
@@ -252,7 +252,7 @@ void IconLayer::preGenerateRenderPasses() {
     renderPassObjectMap = newRenderPassObjectMap;
 }
 
-void IconLayer::onAdded(const std::shared_ptr<MapInterface> &mapInterface) {
+void IconLayer::onAdded(const std::shared_ptr<MapInterface> &mapInterface, int32_t layerIndex) {
     this->mapInterface = mapInterface;
     {
         std::scoped_lock<std::recursive_mutex> lock(addingQueueMutex);
@@ -266,7 +266,7 @@ void IconLayer::onAdded(const std::shared_ptr<MapInterface> &mapInterface) {
         }
     }
     if (isLayerClickable) {
-        mapInterface->getTouchHandler()->addListener(shared_from_this());
+        mapInterface->getTouchHandler()->insertListener(shared_from_this(), layerIndex);
     }
 }
 

--- a/shared/src/map/layers/icon/IconLayer.h
+++ b/shared/src/map/layers/icon/IconLayer.h
@@ -58,7 +58,7 @@ class IconLayer : public IconLayerInterface,
 
     virtual std::vector<std::shared_ptr<::RenderPassInterface>> buildRenderPasses() override;
 
-    virtual void onAdded(const std::shared_ptr<MapInterface> &mapInterface) override;
+    virtual void onAdded(const std::shared_ptr<MapInterface> &mapInterface, int32_t layerIndex) override;
 
     virtual void onRemoved() override;
 

--- a/shared/src/map/layers/line/LineLayer.cpp
+++ b/shared/src/map/layers/line/LineLayer.cpp
@@ -191,7 +191,7 @@ std::vector<std::shared_ptr<::RenderPassInterface>> LineLayer::buildRenderPasses
     }
 }
 
-void LineLayer::onAdded(const std::shared_ptr<MapInterface> &mapInterface) {
+void LineLayer::onAdded(const std::shared_ptr<MapInterface> &mapInterface, int32_t layerIndex) {
     this->mapInterface = mapInterface;
     {
         std::lock_guard<std::recursive_mutex> lock(addingQueueMutex);
@@ -201,7 +201,7 @@ void LineLayer::onAdded(const std::shared_ptr<MapInterface> &mapInterface) {
         addingQueue.clear();
     }
     if (isLayerClickable) {
-        mapInterface->getTouchHandler()->addListener(shared_from_this());
+        mapInterface->getTouchHandler()->insertListener(shared_from_this(), layerIndex);
     }
 }
 

--- a/shared/src/map/layers/polygon/PolygonLayer.cpp
+++ b/shared/src/map/layers/polygon/PolygonLayer.cpp
@@ -247,7 +247,7 @@ std::vector<std::shared_ptr<::RenderPassInterface>> PolygonLayer::buildRenderPas
     }
 }
 
-void PolygonLayer::onAdded(const std::shared_ptr<MapInterface> &mapInterface) {
+void PolygonLayer::onAdded(const std::shared_ptr<MapInterface> &mapInterface, int32_t layerIndex) {
     this->mapInterface = mapInterface;
     {
         std::lock_guard<std::recursive_mutex> lock(addingQueueMutex);
@@ -257,7 +257,7 @@ void PolygonLayer::onAdded(const std::shared_ptr<MapInterface> &mapInterface) {
         addingQueue.clear();
     }
     if (isLayerClickable) {
-        mapInterface->getTouchHandler()->addListener(shared_from_this());
+        mapInterface->getTouchHandler()->insertListener(shared_from_this(), layerIndex);
     }
 }
 

--- a/shared/src/map/layers/text/TextLayer.cpp
+++ b/shared/src/map/layers/text/TextLayer.cpp
@@ -71,7 +71,7 @@ std::vector<std::shared_ptr<::RenderPassInterface>> TextLayer::buildRenderPasses
     }
 }
 
-void TextLayer::onAdded(const std::shared_ptr<MapInterface> &mapInterface) {
+void TextLayer::onAdded(const std::shared_ptr<MapInterface> &mapInterface, int32_t layerIndex) {
     this->mapInterface = mapInterface;
 
     {

--- a/shared/src/map/layers/tiled/Tiled2dMapLayer.cpp
+++ b/shared/src/map/layers/tiled/Tiled2dMapLayer.cpp
@@ -25,7 +25,7 @@ void Tiled2dMapLayer::setSourceInterface(const std::shared_ptr<Tiled2dMapSourceI
     }
 }
 
-void Tiled2dMapLayer::onAdded(const std::shared_ptr<::MapInterface> &mapInterface) {
+void Tiled2dMapLayer::onAdded(const std::shared_ptr<::MapInterface> &mapInterface, int32_t layerIndex) {
     this->mapInterface = mapInterface;
 
     sourceInterface->setMinZoomLevelIdentifier(minZoomLevelIdentifier);

--- a/shared/src/map/layers/tiled/vector/sublayers/Tiled2dMapVectorSubLayer.cpp
+++ b/shared/src/map/layers/tiled/vector/sublayers/Tiled2dMapVectorSubLayer.cpp
@@ -39,7 +39,7 @@ Tiled2dMapVectorSubLayer::buildRenderPasses(const std::unordered_set<Tiled2dMapT
     return newRenderPasses;
 }
 
-void Tiled2dMapVectorSubLayer::onAdded(const std::shared_ptr<MapInterface> &mapInterface) {
+void Tiled2dMapVectorSubLayer::onAdded(const std::shared_ptr<MapInterface> &mapInterface, int32_t layerIndex) {
     this->mapInterface = mapInterface;
 }
 

--- a/shared/src/map/layers/tiled/vector/sublayers/background/Tiled2dMapVectorBackgroundSubLayer.cpp
+++ b/shared/src/map/layers/tiled/vector/sublayers/background/Tiled2dMapVectorBackgroundSubLayer.cpp
@@ -17,8 +17,8 @@
 #include "SchedulerInterface.h"
 #include "LambdaTask.h"
 
-void Tiled2dMapVectorBackgroundSubLayer::onAdded(const std::shared_ptr<MapInterface> &mapInterface) {
-    Tiled2dMapVectorSubLayer::onAdded(mapInterface);
+void Tiled2dMapVectorBackgroundSubLayer::onAdded(const std::shared_ptr<MapInterface> &mapInterface, int32_t layerIndex) {
+    Tiled2dMapVectorSubLayer::onAdded(mapInterface, layerIndex);
     shader = mapInterface->getShaderFactory()->createColorShader();
     object = mapInterface->getGraphicsObjectFactory()->createQuad(shader->asShaderProgramInterface());
 

--- a/shared/src/map/layers/tiled/vector/sublayers/background/Tiled2dMapVectorBackgroundSubLayer.h
+++ b/shared/src/map/layers/tiled/vector/sublayers/background/Tiled2dMapVectorBackgroundSubLayer.h
@@ -22,7 +22,7 @@ public:
 
     virtual void update() override {};
 
-    virtual void onAdded(const std::shared_ptr<MapInterface> &mapInterface) override;
+    virtual void onAdded(const std::shared_ptr<MapInterface> &mapInterface, int32_t layerIndex) override;
 
     virtual void onRemoved() override;
 

--- a/shared/src/map/layers/tiled/vector/sublayers/line/Tiled2dMapVectorLineSubLayer.cpp
+++ b/shared/src/map/layers/tiled/vector/sublayers/line/Tiled2dMapVectorLineSubLayer.cpp
@@ -23,13 +23,11 @@ Tiled2dMapVectorLineSubLayer::Tiled2dMapVectorLineSubLayer(const std::shared_ptr
         : description(description),
           usedKeys(description->getUsedKeys()) {}
 
-void Tiled2dMapVectorLineSubLayer::onAdded(const std::shared_ptr<MapInterface> &mapInterface) {
-    Tiled2dMapVectorSubLayer::onAdded(mapInterface);
-    mapInterface->getTouchHandler()->addListener(shared_from_this());
+void Tiled2dMapVectorLineSubLayer::onAdded(const std::shared_ptr<MapInterface> &mapInterface, int32_t layerIndex) {
+    Tiled2dMapVectorSubLayer::onAdded(mapInterface, layerIndex);
 }
 
 void Tiled2dMapVectorLineSubLayer::onRemoved() {
-    mapInterface->getTouchHandler()->removeListener(shared_from_this());
     Tiled2dMapVectorSubLayer::onRemoved();
 }
 

--- a/shared/src/map/layers/tiled/vector/sublayers/line/Tiled2dMapVectorLineSubLayer.h
+++ b/shared/src/map/layers/tiled/vector/sublayers/line/Tiled2dMapVectorLineSubLayer.h
@@ -28,7 +28,7 @@ public:
 
     virtual void update() override;
 
-    virtual void onAdded(const std::shared_ptr<MapInterface> &mapInterface) override;
+    virtual void onAdded(const std::shared_ptr<MapInterface> &mapInterface, int32_t layerIndex) override;
 
     virtual void onRemoved() override;
 

--- a/shared/src/map/layers/tiled/vector/sublayers/polygon/Tiled2dMapVectorPolygonSubLayer.cpp
+++ b/shared/src/map/layers/tiled/vector/sublayers/polygon/Tiled2dMapVectorPolygonSubLayer.cpp
@@ -45,14 +45,12 @@ namespace mapbox {
 Tiled2dMapVectorPolygonSubLayer::Tiled2dMapVectorPolygonSubLayer(const std::shared_ptr<PolygonVectorLayerDescription> &description)
         : description(description), usedKeys(description->getUsedKeys()) {}
 
-void Tiled2dMapVectorPolygonSubLayer::onAdded(const std::shared_ptr<MapInterface> &mapInterface) {
-    Tiled2dMapVectorSubLayer::onAdded(mapInterface);
-    mapInterface->getTouchHandler()->addListener(shared_from_this());
+void Tiled2dMapVectorPolygonSubLayer::onAdded(const std::shared_ptr<MapInterface> &mapInterface, int32_t layerIndex) {
+    Tiled2dMapVectorSubLayer::onAdded(mapInterface, layerIndex);
     shader = mapInterface->getShaderFactory()->createPolygonGroupShader();
 }
 
 void Tiled2dMapVectorPolygonSubLayer::onRemoved() {
-    mapInterface->getTouchHandler()->removeListener(shared_from_this());
     Tiled2dMapVectorSubLayer::onRemoved();
 }
 

--- a/shared/src/map/layers/tiled/vector/sublayers/polygon/Tiled2dMapVectorPolygonSubLayer.h
+++ b/shared/src/map/layers/tiled/vector/sublayers/polygon/Tiled2dMapVectorPolygonSubLayer.h
@@ -30,7 +30,7 @@ public:
 
     virtual void update() override;
 
-    virtual void onAdded(const std::shared_ptr<MapInterface> &mapInterface) override;
+    virtual void onAdded(const std::shared_ptr<MapInterface> &mapInterface, int32_t layerIndex) override;
 
     virtual void onRemoved() override;
 

--- a/shared/src/map/layers/tiled/vector/sublayers/raster/Tiled2dMapVectorRasterSubLayer.cpp
+++ b/shared/src/map/layers/tiled/vector/sublayers/raster/Tiled2dMapVectorRasterSubLayer.cpp
@@ -14,7 +14,7 @@
 
 Tiled2dMapVectorRasterSubLayer::Tiled2dMapVectorRasterSubLayer(const std::shared_ptr<::RasterVectorLayerDescription> &description,
                                                                const std::vector<std::shared_ptr<::LoaderInterface>> & tileLoaders):
-Tiled2dMapRasterLayer(std::make_shared<Tiled2dMapVectorRasterSubLayerConfig>(description), tileLoaders),
+Tiled2dMapRasterLayer(std::make_shared<Tiled2dMapVectorRasterSubLayerConfig>(description), tileLoaders, false),
 description(description) {}
 
 void Tiled2dMapVectorRasterSubLayer::update() {

--- a/shared/src/map/layers/tiled/vector/sublayers/symbol/Tiled2dMapVectorSymbolSubLayer.cpp
+++ b/shared/src/map/layers/tiled/vector/sublayers/symbol/Tiled2dMapVectorSymbolSubLayer.cpp
@@ -35,17 +35,12 @@ Tiled2dMapVectorSymbolSubLayer::Tiled2dMapVectorSymbolSubLayer(const std::shared
   description(description)
 {}
 
-void Tiled2dMapVectorSymbolSubLayer::onAdded(const std::shared_ptr<MapInterface> &mapInterface) {
-    Tiled2dMapVectorSubLayer::onAdded(mapInterface);
-    mapInterface->getTouchHandler()->addListener(shared_from_this());
+void Tiled2dMapVectorSymbolSubLayer::onAdded(const std::shared_ptr<MapInterface> &mapInterface, int32_t layerIndex) {
+    Tiled2dMapVectorSubLayer::onAdded(mapInterface, layerIndex);
 }
 
 void Tiled2dMapVectorSymbolSubLayer::onRemoved() {
     Tiled2dMapVectorSubLayer::onRemoved();
-
-    if (mapInterface) {
-        mapInterface->getTouchHandler()->removeListener(shared_from_this());
-    }
 }
 
 void Tiled2dMapVectorSymbolSubLayer::pause() {

--- a/shared/src/map/layers/tiled/vector/sublayers/symbol/Tiled2dMapVectorSymbolSubLayer.h
+++ b/shared/src/map/layers/tiled/vector/sublayers/symbol/Tiled2dMapVectorSymbolSubLayer.h
@@ -80,7 +80,7 @@ public:
 
     virtual void update() override;
 
-    virtual void onAdded(const std::shared_ptr<MapInterface> &mapInterface) override;
+    virtual void onAdded(const std::shared_ptr<MapInterface> &mapInterface, int32_t layerIndex) override;
 
     virtual void onRemoved() override;
 


### PR DESCRIPTION
Fix TouchHandler-listener ordering by respecting the index of the layer in the MapScene and properly handling identical indices.