### PR TITLE
Some minor fixes for Server-Side Rendering (OpenGL)

### DIFF
--- a/shared/public/BoundingBox.h
+++ b/shared/public/BoundingBox.h
@@ -13,6 +13,9 @@
 #include <optional>
 #include "RectCoord.h"
 #include "BoundingBoxInterface.h"
+#if defined __LINUX_BUILD__
+#include <cmath>
+#endif
 
 class BoundingBox: public BoundingBoxInterface, public std::enable_shared_from_this<BoundingBox>
 {

--- a/shared/public/LineHelper.h
+++ b/shared/public/LineHelper.h
@@ -10,6 +10,10 @@
 
 #pragma once
 
+#if defined __LINUX_BUILD__
+#include <cmath>
+#endif
+
 #include "CoordinateConversionHelperInterface.h"
 #include "LineInfoInterface.h"
 

--- a/shared/public/Tiled2dMapRasterLayer.h
+++ b/shared/public/Tiled2dMapRasterLayer.h
@@ -61,8 +61,8 @@ public:
     virtual void onTilesUpdated() override;
 
     virtual void setupTiles(
-            const std::vector<const std::pair<const Tiled2dMapRasterTileInfo, std::shared_ptr<Textured2dLayerObject>>> &tilesToSetup,
-            const std::vector<const std::pair<const Tiled2dMapRasterTileInfo, std::shared_ptr<Textured2dLayerObject>>> &tilesToClean);
+            const std::vector< std::pair<const Tiled2dMapRasterTileInfo, std::shared_ptr<Textured2dLayerObject>>> &tilesToSetup,
+            const std::vector< std::pair<const Tiled2dMapRasterTileInfo, std::shared_ptr<Textured2dLayerObject>>> &tilesToClean);
 
     virtual void generateRenderPasses();
 
@@ -103,8 +103,8 @@ public:
     virtual std::shared_ptr<::Tiled2dMapLayerConfig> getConfig() override;
 
 private:
-    virtual void updateMaskObjects(const std::vector<const std::shared_ptr<MaskingObjectInterface>> &newMaskObjects,
-                                   const std::vector<const std::shared_ptr<MaskingObjectInterface>> &obsoleteMaskObjects);
+    virtual void updateMaskObjects(const std::vector< std::shared_ptr<MaskingObjectInterface>> &newMaskObjects,
+                                   const std::vector< std::shared_ptr<MaskingObjectInterface>> &obsoleteMaskObjects);
 
     virtual void enableAnimations(bool enabled) override;
 

--- a/shared/public/Tiled2dMapSource.h
+++ b/shared/public/Tiled2dMapSource.h
@@ -94,7 +94,7 @@ public:
 
     void setTileReady(const Tiled2dMapTileInfo &tile);
 
-    void setTilesReady(const std::vector<const Tiled2dMapTileInfo> &tiles);
+    void setTilesReady(const std::vector< Tiled2dMapTileInfo> &tiles);
 
     virtual L loadTile(Tiled2dMapTileInfo tile, size_t loaderIndex) = 0;
 

--- a/shared/public/Tiled2dMapSourceImpl.h
+++ b/shared/public/Tiled2dMapSourceImpl.h
@@ -833,7 +833,7 @@ void Tiled2dMapSource<T, L, R>::setTileReady(const Tiled2dMapTileInfo &tile) {
 }
 
 template<class T, class L, class R>
-void Tiled2dMapSource<T, L, R>::setTilesReady(const std::vector<const Tiled2dMapTileInfo> &tiles) {
+void Tiled2dMapSource<T, L, R>::setTilesReady(const std::vector< Tiled2dMapTileInfo> &tiles) {
     bool needsUpdate = false;
     {
         std::scoped_lock<std::recursive_mutex, std::recursive_mutex> lock(currentTilesMutex, tilesReadyMutex);

--- a/shared/public/Tiled2dMapVectorLayer.h
+++ b/shared/public/Tiled2dMapVectorLayer.h
@@ -131,7 +131,7 @@ private:
 
     void initializeVectorLayer(const std::vector<std::shared_ptr<LayerInterface>> &newSublayers);
 
-    virtual void updateMaskObjects(const std::unordered_map<Tiled2dMapTileInfo, Tiled2dMapLayerMaskWrapper> &toSetupMaskObject, const std::vector<const std::shared_ptr<MaskingObjectInterface>> &obsoleteMaskObjects);
+    virtual void updateMaskObjects(const std::unordered_map<Tiled2dMapTileInfo, Tiled2dMapLayerMaskWrapper> &toSetupMaskObject, const std::vector< std::shared_ptr<MaskingObjectInterface>> &obsoleteMaskObjects);
 
     int32_t layerIndex = -1;
 

--- a/shared/public/Tiled2dMapVectorStyleParser.h
+++ b/shared/public/Tiled2dMapVectorStyleParser.h
@@ -108,7 +108,7 @@ public:
 
             // Example: ["all", [ "in", "admin_level", 2, 4 ], [ "!=", "maritime", 1] ]
             else if (isExpression(json[0], allExpression)) {
-                std::vector<const std::shared_ptr<Value>> values;
+                std::vector< std::shared_ptr<Value>> values;
                 for (auto it = json.begin() + 1; it != json.end(); it++) {
                     auto const &v = parseValue(*it);
                     if (v != nullptr) {
@@ -120,7 +120,7 @@ public:
 
             // Example: ["any", [ "in", "admin_level", 2, 4 ], [ "!=", "maritime", 1] ]
             else if (isExpression(json[0], anyExpression)) {
-                std::vector<const std::shared_ptr<Value>> values;
+                std::vector< std::shared_ptr<Value>> values;
                 for (auto it = json.begin() + 1; it != json.end(); it++) {
                     auto const &v = parseValue(*it);
                     if (v != nullptr) {

--- a/shared/public/Value.h
+++ b/shared/public/Value.h
@@ -1036,7 +1036,7 @@ private:
 
 class AllValue: public Value {
 public:
-    AllValue(const std::vector<const std::shared_ptr<Value>> values) : values(values) {}
+    AllValue(const std::vector< std::shared_ptr<Value>> values) : values(values) {}
 
     std::unordered_set<std::string> getUsedKeys() override {
         std::unordered_set<std::string> usedKeys;
@@ -1057,12 +1057,12 @@ public:
     };
 
 private:
-    const std::vector<const std::shared_ptr<Value>> values;
+    const std::vector< std::shared_ptr<Value>> values;
 };
 
 class AnyValue: public Value {
 public:
-    AnyValue(const std::vector<const std::shared_ptr<Value>> values) : values(values) {}
+    AnyValue(const std::vector< std::shared_ptr<Value>> values) : values(values) {}
 
     std::unordered_set<std::string> getUsedKeys() override {
         std::unordered_set<std::string> usedKeys;
@@ -1083,7 +1083,7 @@ public:
     };
 
 private:
-    const std::vector<const std::shared_ptr<Value>> values;
+    const std::vector< std::shared_ptr<Value>> values;
 };
 
 class PropertyCompareValue: public Value {

--- a/shared/src/graphics/SceneInterface.cpp
+++ b/shared/src/graphics/SceneInterface.cpp
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: MPL-2.0
  */
 
-#ifdef __ANDROID__
+#if defined __ANDROID__  || defined __OPENGL__
 
 #include "GraphicsObjectFactoryOpenGl.h"
 #include "OpenGlContext.h"
@@ -25,7 +25,7 @@ std::shared_ptr<SceneInterface> SceneInterface::create(const std::shared_ptr<::G
 }
 
 std::shared_ptr<SceneInterface> SceneInterface::createWithOpenGl() {
-#ifdef __ANDROID__
+#if defined __ANDROID || defined __OPENGL__
     auto scene = std::static_pointer_cast<SceneInterface>(std::make_shared<Scene>(std::make_shared<GraphicsObjectFactoryOpenGl>(),
                                                                                   std::make_shared<ShaderFactoryOpenGl>(),
                                                                                   std::make_shared<OpenGlContext>()));

--- a/shared/src/logger/Logger.cpp
+++ b/shared/src/logger/Logger.cpp
@@ -28,6 +28,11 @@ int __android_log_print(int prio, const char *tag, const char *fmt, ...);
 #include <os/log.h>
 #endif
 
+#if defined __OPENGL__
+#include "cxxgen.h"
+#include <string>
+#endif
+
 Logger::Logger(int p){
     priority = p;
 }
@@ -67,6 +72,16 @@ void Logger::log(int prio, const char *tag, const char *fmt, ...) const {
     va_start(args, fmt);
     __android_log_print(androidPrio, tag, fmt, args);
     va_end(args);
+#endif
+
+#if defined __OPENGL__
+    char buffer[1024];
+    va_list args;
+    va_start(args, fmt);
+    vsprintf(buffer, fmt, args);
+    va_end(args);
+
+    log_rs(std::string(buffer));
 #endif
 
 #if (defined(__APPLE__) && !defined(BANDIT_TESTING)) || defined(_WIN32)

--- a/shared/src/map/MapInterface.cpp
+++ b/shared/src/map/MapInterface.cpp
@@ -22,7 +22,7 @@ std::shared_ptr<MapInterface> MapInterface::create(const std::shared_ptr<::Graph
 std::shared_ptr<MapInterface> MapInterface::createWithOpenGl(const MapConfig &mapConfig,
                                                              const std::shared_ptr<::SchedulerInterface> &scheduler,
                                                              float pixelDensity) {
-#ifdef __ANDROID__
+#if defined __ANDROID__ || defined __OPENGL__
     return std::make_shared<MapScene>(SceneInterface::createWithOpenGl(), mapConfig, scheduler, pixelDensity);
 #else
     return nullptr;

--- a/shared/src/map/coordinates/CoordinateConversionHelper.h
+++ b/shared/src/map/coordinates/CoordinateConversionHelper.h
@@ -21,6 +21,10 @@
 #include <unordered_map>
 #include <vector>
 
+#if defined __LINUX_BUILD__
+#include <cmath>
+#endif
+
 class CoordinateConversionHelper : public CoordinateConversionHelperInterface {
   public:
     CoordinateConversionHelper(MapCoordinateSystem mapCoordinateSystem);

--- a/shared/src/map/layers/icon/IconLayer.h
+++ b/shared/src/map/layers/icon/IconLayer.h
@@ -21,6 +21,10 @@
 #include <mutex>
 #include <unordered_map>
 #include <unordered_set>
+#if defined __LINUX_BUILD__
+#include <atomic>
+#include <cmath>
+#endif
 
 class IconLayer : public IconLayerInterface,
                   public SimpleLayerInterface,

--- a/shared/src/map/layers/polygon/PolygonLayer.cpp
+++ b/shared/src/map/layers/polygon/PolygonLayer.cpp
@@ -116,7 +116,7 @@ void PolygonLayer::addAll(const std::vector<PolygonInfo> &polygons) {
             polygonObject->setColor(polygon.color);
 
             polygonGraphicsObjects.push_back(polygonGraphicsObject);
-            this->polygons[polygon.identifier].push_back(std::make_tuple(polygon, polygonObject));
+            this->polygons[polygon.identifier].push_back(std::make_pair(polygon, polygonObject));
         }
     }
 

--- a/shared/src/map/layers/tiled/raster/Tiled2dMapRasterLayer.cpp
+++ b/shared/src/map/layers/tiled/raster/Tiled2dMapRasterLayer.cpp
@@ -150,9 +150,9 @@ void Tiled2dMapRasterLayer::onTilesUpdated() {
         }
 
         auto currentTileInfos = rasterSource->getCurrentTiles();
-        std::vector<const std::pair<const Tiled2dMapRasterTileInfo, std::shared_ptr<Textured2dLayerObject>>> tilesToSetup, tilesToClean;
-        std::vector<const std::shared_ptr<MaskingObjectInterface>> newMaskObjects;
-        std::vector<const std::shared_ptr<MaskingObjectInterface>> obsoleteMaskObjects;
+        std::vector< std::pair<const Tiled2dMapRasterTileInfo, std::shared_ptr<Textured2dLayerObject>>> tilesToSetup, tilesToClean;
+        std::vector< std::shared_ptr<MaskingObjectInterface>> newMaskObjects;
+        std::vector< std::shared_ptr<MaskingObjectInterface>> obsoleteMaskObjects;
 
         {
             std::lock_guard<std::recursive_mutex> overlayLock(updateMutex);
@@ -257,8 +257,8 @@ void Tiled2dMapRasterLayer::onTilesUpdated() {
 }
 
 
-void Tiled2dMapRasterLayer::updateMaskObjects(const std::vector<const std::shared_ptr<MaskingObjectInterface>> &newMaskObjects,
-                                              const std::vector<const std::shared_ptr<MaskingObjectInterface>> &obsoleteMaskObjects) {
+void Tiled2dMapRasterLayer::updateMaskObjects(const std::vector< std::shared_ptr<MaskingObjectInterface>> &newMaskObjects,
+                                              const std::vector< std::shared_ptr<MaskingObjectInterface>> &obsoleteMaskObjects) {
     if (!mapInterface) return;
     std::lock_guard<std::recursive_mutex> overlayLock(updateMutex);
     for (const auto &mask : newMaskObjects) {
@@ -273,15 +273,15 @@ void Tiled2dMapRasterLayer::updateMaskObjects(const std::vector<const std::share
 
 
 void Tiled2dMapRasterLayer::setupTiles(
-        const std::vector<const std::pair<const Tiled2dMapRasterTileInfo, std::shared_ptr<Textured2dLayerObject>>> &tilesToSetup,
-        const std::vector<const std::pair<const Tiled2dMapRasterTileInfo, std::shared_ptr<Textured2dLayerObject>>> &tilesToClean) {
+        const std::vector< std::pair<const Tiled2dMapRasterTileInfo, std::shared_ptr<Textured2dLayerObject>>> &tilesToSetup,
+        const std::vector< std::pair<const Tiled2dMapRasterTileInfo, std::shared_ptr<Textured2dLayerObject>>> &tilesToClean) {
     auto mapInterface = this->mapInterface;
     auto renderingContext = mapInterface ? mapInterface->getRenderingContext() : nullptr;
     if (!renderingContext) {
         return;
     }
     
-    std::vector<const Tiled2dMapTileInfo> tilesReady;
+    std::vector< Tiled2dMapTileInfo> tilesReady;
     {
         std::lock_guard<std::recursive_mutex> overlayLock(updateMutex);
 

--- a/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayer.cpp
+++ b/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayer.cpp
@@ -587,7 +587,7 @@ void Tiled2dMapVectorLayer::onTilesUpdated() {
             }
         }
 
-        std::vector<const std::shared_ptr<MaskingObjectInterface>> toClearMaskObjects;
+        std::vector< std::shared_ptr<MaskingObjectInterface>> toClearMaskObjects;
 
 
         for (const auto &newMaskEntry : newTileMasks) {
@@ -642,7 +642,7 @@ void Tiled2dMapVectorLayer::onTilesUpdated() {
 }
 
 void Tiled2dMapVectorLayer::updateMaskObjects(const std::unordered_map<Tiled2dMapTileInfo, Tiled2dMapLayerMaskWrapper> &toSetupMaskObject,
-                                              const std::vector<const std::shared_ptr<MaskingObjectInterface>> &obsoleteMaskObjects) {
+                                              const std::vector< std::shared_ptr<MaskingObjectInterface>> &obsoleteMaskObjects) {
     auto mapInterface = this->mapInterface;
     auto renderingContext = mapInterface ? mapInterface->getRenderingContext() : nullptr;
     if (!renderingContext) return;

--- a/shared/src/map/layers/tiled/wmts/WmtsTiled2dMapLayerConfig.h
+++ b/shared/src/map/layers/tiled/wmts/WmtsTiled2dMapLayerConfig.h
@@ -15,6 +15,10 @@
 #include "Tiled2dMapZoomLevelInfo.h"
 #include "WmtsLayerDescription.h"
 
+#if defined __LINUX_BUILD__
+#include <cstring>
+#endif
+
 class WmtsTiled2dMapLayerConfig : public Tiled2dMapLayerConfig {
   public:
     WmtsTiled2dMapLayerConfig(const WmtsLayerDescription &description, std::vector<Tiled2dMapZoomLevelInfo> zoomLevelInfo,


### PR DESCRIPTION
- Add includes in header files (cstring, memory, mutex and so on)
- remove const in vector since it is non standard compliant 
- add switches for OpenGL (Serverside) build (__ANDROID__ includes too much)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `destroy` method across various interfaces and classes for proper cleanup.
  - Updated version to `1.5.3` for the app and associated libraries.

- **Enhancements**
  - Improved map loading performance with updated `DataLoader` initialization.
  - Streamlined map view cleanup with enhanced `onDestroy` behavior.
  - Optimized task scheduling with local `scheduler` variable usage.

- **Bug Fixes**
  - Fixed potential null reference issues in task scheduling logic.

- **Documentation**
  - Updated library version in `readme.md` files for both Android and iOS.

- **Refactor**
  - Removed redundant code and improved null handling in callback setting.
  - Enhanced conditional compilation directives for better platform support.

- **Style**
  - Standardized method signatures by removing `const` qualifiers from `std::vector` parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->