### PR TITLE
updates package to fix xcode 14.3.0 problems

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -163,6 +163,8 @@ let package = Package(
                 .headerSearchPath("src/external/pugixml"),
                 .define("DEBUG", to: "1", .when(configuration: .debug)),
                 .define("NDEBUG", to: "1", .when(configuration: .release)),
+                .define("_LIBCPP_DISABLE_AVAILABILITY", to: "1",.when(configuration: .debug)),
+                .define("_LIBCPP_DISABLE_AVAILABILITY", to: "1",.when(configuration: .release))
             ]
         ),
     ],


### PR DESCRIPTION
Availability ist zu strikt eingestellt, da es auch auf iOS 12.0 funktionieren sollte, man es aber zur Buildzeit noch nicht weiss.