### PR TITLE
Release 1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,16 @@
 # Changelog for Open Mobile Maps
 
-## Version 1.5.2 (02.05.2022)
+## Version 1.5.3 (16.05.2023)
+- Improved MapInterface teardown
+
+## Version 1.5.2 (02.05.2023)
 - Fix for Android context memory leak
 
-## Version 1.5.1 (14.04.2022)
+## Version 1.5.1 (14.04.2023)
 - Fix for XCode 14.3.0
 - Convenience function for RectCoord to PolygonCoord conversion
 
-## Version 1.5.0 (23.03.2022)
+## Version 1.5.0 (23.03.2023)
 - implements vector icon anchor
 - evaluate color from feature context 
 - expose bounding box in djinni

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -26,8 +26,8 @@ SNAPSHOT_REPOSITORY_URL=https://oss.sonatype.org/content/repositories/snapshots/
 
 GROUP=io.openmobilemaps
 POM_ARTIFACT_ID=mapscore
-VERSION_NAME=1.5.2
-VERSION_CODE=152
+VERSION_NAME=1.5.3
+VERSION_CODE=153
 
 POM_NAME=mapscore
 POM_PACKAGING=aar

--- a/android/readme.md
+++ b/android/readme.md
@@ -65,7 +65,7 @@ This library is available on MavenCentral. To add it to your Android project, ad
 
 ```
 dependencies {
-  implementation 'io.openmobilemaps:mapscore:1.5.2'
+  implementation 'io.openmobilemaps:mapscore:1.5.3'
 }
 ```
 

--- a/android/src/main/java/io/openmobilemaps/mapscore/map/scheduling/AndroidScheduler.kt
+++ b/android/src/main/java/io/openmobilemaps/mapscore/map/scheduling/AndroidScheduler.kt
@@ -20,7 +20,7 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
 class AndroidScheduler(
-	private val schedulerCallback: AndroidSchedulerCallback,
+	schedulerCallback: AndroidSchedulerCallback,
 	private val dispatchers: AndroidSchedulerDispatchers = AndroidSchedulerDispatchers()
 ) : SchedulerInterface() {
 
@@ -30,6 +30,8 @@ class AndroidScheduler(
 	private val taskQueueMap: ConcurrentHashMap<TaskPriority, ConcurrentLinkedQueue<TaskInterface>> = ConcurrentHashMap()
 	private val runningTasksMap: ConcurrentHashMap<String, Job> = ConcurrentHashMap()
 	private val delayedTaskMap: ConcurrentHashMap<String, Job> = ConcurrentHashMap()
+
+	private var schedulerCallback: AndroidSchedulerCallback? = schedulerCallback
 
 	init {
 		TaskPriority.values().forEach { taskQueueMap.put(it, ConcurrentLinkedQueue()) }
@@ -74,7 +76,7 @@ class AndroidScheduler(
 	private fun scheduleTask(task: TaskInterface) {
 		val executionEnvironment = task.getConfig().executionEnvironment
 		if (executionEnvironment == ExecutionEnvironment.GRAPHICS) {
-			schedulerCallback.scheduleOnGlThread(task)
+			schedulerCallback?.scheduleOnGlThread(task)
 		} else {
 			val dispatcher = when (executionEnvironment) {
 				ExecutionEnvironment.IO -> dispatchers.io
@@ -122,6 +124,10 @@ class AndroidScheduler(
 				}
 			}
 		}
+	}
+
+	override fun destroy() {
+		schedulerCallback = null
 	}
 
 	fun launchCoroutine(

--- a/android/src/main/java/io/openmobilemaps/mapscore/map/view/MapView.kt
+++ b/android/src/main/java/io/openmobilemaps/mapscore/map/view/MapView.kt
@@ -122,7 +122,7 @@ open class MapView @JvmOverloads constructor(context: Context, attrs: AttributeS
 	@OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
 	open fun onDestroy() {
 		setRenderer(null)
-		mapInterface?.setCallbackHandler(null)
+		mapInterface?.destroy()
 		mapInterface = null
 		scheduler = null
 		touchHandler = null

--- a/bridging/android/java/io/openmobilemaps/mapscore/shared/map/MapInterface.kt
+++ b/bridging/android/java/io/openmobilemaps/mapscore/shared/map/MapInterface.kt
@@ -53,6 +53,8 @@ abstract class MapInterface {
 
     abstract fun pause()
 
+    abstract fun destroy()
+
     /**
      * changes bounds to bounds, checks all layers for readiness, and updates callbacks, timeout in
      * seconds, always draw the frame when state is updated in the ready callbacks
@@ -228,6 +230,12 @@ abstract class MapInterface {
             native_pause(this.nativeRef)
         }
         private external fun native_pause(_nativeRef: Long)
+
+        override fun destroy() {
+            assert(!this.destroyed.get()) { error("trying to use a destroyed object") }
+            native_destroy(this.nativeRef)
+        }
+        private external fun native_destroy(_nativeRef: Long)
 
         override fun drawReadyFrame(bounds: io.openmobilemaps.mapscore.shared.map.coordinates.RectCoord, timeout: Float, callbacks: MapReadyCallbackInterface) {
             assert(!this.destroyed.get()) { error("trying to use a destroyed object") }

--- a/bridging/android/java/io/openmobilemaps/mapscore/shared/map/scheduling/SchedulerInterface.kt
+++ b/bridging/android/java/io/openmobilemaps/mapscore/shared/map/scheduling/SchedulerInterface.kt
@@ -19,6 +19,8 @@ abstract class SchedulerInterface {
 
     abstract fun resume()
 
+    abstract fun destroy()
+
     private class CppProxy : SchedulerInterface {
         private val nativeRef: Long
         private val destroyed: AtomicBoolean = AtomicBoolean(false)
@@ -72,5 +74,11 @@ abstract class SchedulerInterface {
             native_resume(this.nativeRef)
         }
         private external fun native_resume(_nativeRef: Long)
+
+        override fun destroy() {
+            assert(!this.destroyed.get()) { error("trying to use a destroyed object") }
+            native_destroy(this.nativeRef)
+        }
+        private external fun native_destroy(_nativeRef: Long)
     }
 }

--- a/bridging/android/jni/map/NativeMapInterface.cpp
+++ b/bridging/android/jni/map/NativeMapInterface.cpp
@@ -277,6 +277,15 @@ CJNIEXPORT void JNICALL Java_io_openmobilemaps_mapscore_shared_map_MapInterface_
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 
+CJNIEXPORT void JNICALL Java_io_openmobilemaps_mapscore_shared_map_MapInterface_00024CppProxy_native_1destroy(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::MapInterface>(nativeRef);
+        ref->destroy();
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
+}
+
 CJNIEXPORT void JNICALL Java_io_openmobilemaps_mapscore_shared_map_MapInterface_00024CppProxy_native_1drawReadyFrame(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, ::djinni_generated::NativeRectCoord::JniType j_bounds, jfloat j_timeout, jobject j_callbacks)
 {
     try {

--- a/bridging/android/jni/map/scheduling/NativeSchedulerInterface.cpp
+++ b/bridging/android/jni/map/scheduling/NativeSchedulerInterface.cpp
@@ -60,6 +60,13 @@ void NativeSchedulerInterface::JavaProxy::resume() {
     jniEnv->CallVoidMethod(Handle::get().get(), data.method_resume);
     ::djinni::jniExceptionCheck(jniEnv);
 }
+void NativeSchedulerInterface::JavaProxy::destroy() {
+    auto jniEnv = ::djinni::jniGetThreadEnv();
+    ::djinni::JniLocalScope jscope(jniEnv, 10);
+    const auto& data = ::djinni::JniClass<::djinni_generated::NativeSchedulerInterface>::get();
+    jniEnv->CallVoidMethod(Handle::get().get(), data.method_destroy);
+    ::djinni::jniExceptionCheck(jniEnv);
+}
 
 CJNIEXPORT void JNICALL Java_io_openmobilemaps_mapscore_shared_map_scheduling_SchedulerInterface_00024CppProxy_nativeDestroy(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef)
 {
@@ -120,6 +127,15 @@ CJNIEXPORT void JNICALL Java_io_openmobilemaps_mapscore_shared_map_scheduling_Sc
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
         const auto& ref = ::djinni::objectFromHandleAddress<::SchedulerInterface>(nativeRef);
         ref->resume();
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
+}
+
+CJNIEXPORT void JNICALL Java_io_openmobilemaps_mapscore_shared_map_scheduling_SchedulerInterface_00024CppProxy_native_1destroy(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::SchedulerInterface>(nativeRef);
+        ref->destroy();
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 

--- a/bridging/android/jni/map/scheduling/NativeSchedulerInterface.h
+++ b/bridging/android/jni/map/scheduling/NativeSchedulerInterface.h
@@ -39,6 +39,7 @@ private:
         void clear() override;
         void pause() override;
         void resume() override;
+        void destroy() override;
 
     private:
         friend ::djinni::JniInterface<::SchedulerInterface, ::djinni_generated::NativeSchedulerInterface>;
@@ -51,6 +52,7 @@ private:
     const jmethodID method_clear { ::djinni::jniGetMethodID(clazz.get(), "clear", "()V") };
     const jmethodID method_pause { ::djinni::jniGetMethodID(clazz.get(), "pause", "()V") };
     const jmethodID method_resume { ::djinni::jniGetMethodID(clazz.get(), "resume", "()V") };
+    const jmethodID method_destroy { ::djinni::jniGetMethodID(clazz.get(), "destroy", "()V") };
 };
 
 }  // namespace djinni_generated

--- a/bridging/ios/MCMapInterface+Private.mm
+++ b/bridging/ios/MCMapInterface+Private.mm
@@ -225,6 +225,12 @@ static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for th
     } DJINNI_TRANSLATE_EXCEPTIONS()
 }
 
+- (void)destroy {
+    try {
+        _cppRefHandle.get()->destroy();
+    } DJINNI_TRANSLATE_EXCEPTIONS()
+}
+
 - (void)drawReadyFrame:(nonnull MCRectCoord *)bounds
                timeout:(float)timeout
              callbacks:(nullable id<MCMapReadyCallbackInterface>)callbacks {

--- a/bridging/ios/MCMapInterface.h
+++ b/bridging/ios/MCMapInterface.h
@@ -81,6 +81,8 @@
 
 - (void)pause;
 
+- (void)destroy;
+
 /**
  * changes bounds to bounds, checks all layers for readiness, and updates callbacks, timeout in
  * seconds, always draw the frame when state is updated in the ready callbacks

--- a/bridging/ios/MCSchedulerInterface+Private.mm
+++ b/bridging/ios/MCSchedulerInterface+Private.mm
@@ -68,6 +68,12 @@ static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for th
     } DJINNI_TRANSLATE_EXCEPTIONS()
 }
 
+- (void)destroy {
+    try {
+        _cppRefHandle.get()->destroy();
+    } DJINNI_TRANSLATE_EXCEPTIONS()
+}
+
 namespace djinni_generated {
 
 class SchedulerInterface::ObjcProxy final
@@ -111,6 +117,12 @@ public:
     {
         @autoreleasepool {
             [djinni_private_get_proxied_objc_object() resume];
+        }
+    }
+    void destroy() override
+    {
+        @autoreleasepool {
+            [djinni_private_get_proxied_objc_object() destroy];
         }
     }
 };

--- a/bridging/ios/MCSchedulerInterface.h
+++ b/bridging/ios/MCSchedulerInterface.h
@@ -19,4 +19,6 @@
 
 - (void)resume;
 
+- (void)destroy;
+
 @end

--- a/djinni/map/core.djinni
+++ b/djinni/map/core.djinni
@@ -54,6 +54,7 @@ map_interface = interface +c {
     draw_frame();
     resume();
     pause();
+    destroy();
 
     # changes bounds to bounds, checks all layers for readiness, and updates callbacks, timeout in
     # seconds, always draw the frame when state is updated in the ready callbacks

--- a/djinni/map/scheduling/task_scheduler.djinni
+++ b/djinni/map/scheduling/task_scheduler.djinni
@@ -5,6 +5,7 @@ scheduler_interface = interface +c +j +o {
     clear();
     pause();
     resume();
+    destroy();
 }
 
 task_interface = interface +c +j +o {

--- a/ios/maps/Scheduling/MCScheduler.swift
+++ b/ios/maps/Scheduling/MCScheduler.swift
@@ -122,6 +122,10 @@ open class MCScheduler: MCSchedulerInterface {
             self.graphicsQueue.isSuspended = false
         }
     }
+
+    public func destroy() {
+        // not used
+    }
 }
 
 private extension OperationQueue {

--- a/ios/readme.md
+++ b/ios/readme.md
@@ -31,7 +31,7 @@ For App integration within XCode, add this package to your App target. To do thi
 Once you have your Swift package set up, adding Open Mobile Maps as a dependency is as easy as adding it to the dependencies value of your Package.swift.
 ```swift
 dependencies: [
-    .package(url: "https://github.com/openmobilemaps/maps-core.git", .upToNextMajor(from: "1.5.2"))
+    .package(url: "https://github.com/openmobilemaps/maps-core.git", .upToNextMajor(from: "1.5.3"))
 ]
 ```
 

--- a/shared/public/MapInterface.h
+++ b/shared/public/MapInterface.h
@@ -77,6 +77,8 @@ public:
 
     virtual void pause() = 0;
 
+    virtual void destroy() = 0;
+
     /**
      * changes bounds to bounds, checks all layers for readiness, and updates callbacks, timeout in
      * seconds, always draw the frame when state is updated in the ready callbacks

--- a/shared/public/SchedulerInterface.h
+++ b/shared/public/SchedulerInterface.h
@@ -24,4 +24,6 @@ public:
     virtual void pause() = 0;
 
     virtual void resume() = 0;
+
+    virtual void destroy() = 0;
 };

--- a/shared/src/MapsCoreSharedModule.cpp
+++ b/shared/src/MapsCoreSharedModule.cpp
@@ -10,4 +10,4 @@
 
 #include "MapsCoreSharedModule.h"
 
-std::string MapsCoreSharedModule::version() { return "1.5.2"; }
+std::string MapsCoreSharedModule::version() { return "1.5.3"; }

--- a/shared/src/map/MapScene.cpp
+++ b/shared/src/map/MapScene.cpp
@@ -269,7 +269,11 @@ void MapScene::pause() {
         }));
 }
 
-
+void MapScene::destroy() {
+    scheduler->destroy();
+    scheduler = nullptr;
+    callbackHandler = nullptr;
+}
 
 void MapScene::drawReadyFrame(const ::RectCoord &bounds, float timeout,
                               const std::shared_ptr<MapReadyCallbackInterface> &callbacks) {

--- a/shared/src/map/MapScene.h
+++ b/shared/src/map/MapScene.h
@@ -72,6 +72,8 @@ class MapScene : public MapInterface, public SceneCallbackInterface, public std:
 
     virtual void pause() override;
 
+    virtual void destroy() override;
+
     virtual void drawReadyFrame(const ::RectCoord &bounds, float timeout,
                                 const std::shared_ptr<MapReadyCallbackInterface> &callbacks) override;
 

--- a/shared/src/map/layers/text/TextLayer.cpp
+++ b/shared/src/map/layers/text/TextLayer.cpp
@@ -135,7 +135,8 @@ void TextLayer::show() {
 void TextLayer::clear() {
     auto lockSelfPtr = shared_from_this();
     auto mapInterface = lockSelfPtr ? lockSelfPtr->mapInterface : nullptr;
-    if (!mapInterface) {
+    auto scheduler = mapInterface ? mapInterface->getScheduler() : nullptr;
+    if (!scheduler) {
         std::lock_guard<std::recursive_mutex> lock(addingQueueMutex);
         addingQueue.clear();
         return;
@@ -144,7 +145,7 @@ void TextLayer::clear() {
     {
         std::lock_guard<std::recursive_mutex> lock(textMutex);
         auto textsToClear = texts;
-        mapInterface->getScheduler()->addTask(std::make_shared<LambdaTask>(
+        scheduler->addTask(std::make_shared<LambdaTask>(
             TaskConfig("TextLayer_clear", 0, TaskPriority::NORMAL, ExecutionEnvironment::GRAPHICS), [=] {
                 for (auto &text : textsToClear) {
                     text.second->getTextObject()->asGraphicsObject()->clear();
@@ -189,7 +190,8 @@ void TextLayer::add(const std::shared_ptr<TextInfoInterface> &text) { addTexts({
 void TextLayer::addTexts(const std::vector<std::shared_ptr<TextInfoInterface>> &texts) {
     auto lockSelfPtr = shared_from_this();
     auto mapInterface = lockSelfPtr ? lockSelfPtr->mapInterface : nullptr;
-    if (!mapInterface) {
+    auto scheduler = mapInterface ? mapInterface->getScheduler() : nullptr;
+    if (!scheduler) {
         std::lock_guard<std::recursive_mutex> lock(addingQueueMutex);
         for (const auto &text : texts) {
             addingQueue.insert(text);
@@ -218,7 +220,7 @@ void TextLayer::addTexts(const std::vector<std::shared_ptr<TextInfoInterface>> &
     std::weak_ptr<TextLayer> weakSelfPtr = std::dynamic_pointer_cast<TextLayer>(shared_from_this());
     std::string taskId =
         "TextLayer_setup_coll_" + std::get<0>(textObjects.at(0))->getText().begin()->text + "_[" + std::to_string(textObjects.size()) + "]";
-    mapInterface->getScheduler()->addTask(std::make_shared<LambdaTask>(
+    scheduler->addTask(std::make_shared<LambdaTask>(
         TaskConfig(taskId, 0, TaskPriority::NORMAL, ExecutionEnvironment::GRAPHICS), [weakSelfPtr, textObjects] {
             auto selfPtr = weakSelfPtr.lock();
             if (selfPtr)

--- a/shared/src/map/layers/tiled/raster/Tiled2dMapRasterLayer.cpp
+++ b/shared/src/map/layers/tiled/raster/Tiled2dMapRasterLayer.cpp
@@ -140,7 +140,8 @@ void Tiled2dMapRasterLayer::onTilesUpdated() {
     auto graphicsFactory = mapInterface ? mapInterface->getGraphicsObjectFactory() : nullptr;
     auto coordinateConverterHelper = mapInterface ? mapInterface->getCoordinateConverterHelper() : nullptr;
     auto shaderFactory = mapInterface ? mapInterface->getShaderFactory() : nullptr;
-    if (!graphicsFactory || !shaderFactory) {
+    auto scheduler = mapInterface ? mapInterface->getScheduler() : nullptr;
+    if (!graphicsFactory || !shaderFactory || !scheduler) {
         return;
     }
 
@@ -244,7 +245,7 @@ void Tiled2dMapRasterLayer::onTilesUpdated() {
 
         std::weak_ptr<Tiled2dMapRasterLayer> weakSelfPtr = std::dynamic_pointer_cast<Tiled2dMapRasterLayer>(shared_from_this());
 
-        mapInterface->getScheduler()->addTask(std::make_shared<LambdaTask>(
+        scheduler->addTask(std::make_shared<LambdaTask>(
                 TaskConfig("Tiled2dMapRasterLayer_onTilesUpdated", 0, TaskPriority::NORMAL, ExecutionEnvironment::GRAPHICS),
                 [weakSelfPtr, tilesToSetup, tilesToClean, newMaskObjects, obsoleteMaskObjects] {
                     auto selfPtr = weakSelfPtr.lock();

--- a/shared/src/map/layers/tiled/vector/sublayers/background/Tiled2dMapVectorBackgroundSubLayer.cpp
+++ b/shared/src/map/layers/tiled/vector/sublayers/background/Tiled2dMapVectorBackgroundSubLayer.cpp
@@ -37,7 +37,11 @@ void Tiled2dMapVectorBackgroundSubLayer::onAdded(const std::shared_ptr<MapInterf
     };
 
     std::weak_ptr<Tiled2dMapVectorBackgroundSubLayer> weakSelfPtr = weak_from_this();
-    mapInterface->getScheduler()->addTask(std::make_shared<LambdaTask>(
+    auto scheduler = mapInterface->getScheduler();
+    if (!scheduler) {
+        return;
+    }
+    scheduler->addTask(std::make_shared<LambdaTask>(
            TaskConfig("Tiled2dMapVectorBackgroundSubLayer setup", 0, TaskPriority::NORMAL, ExecutionEnvironment::GRAPHICS), [weakSelfPtr] {
                 auto selfPtr = weakSelfPtr.lock();
                 if (!selfPtr) {

--- a/shared/src/map/layers/tiled/vector/sublayers/line/Tiled2dMapVectorLineSubLayer.cpp
+++ b/shared/src/map/layers/tiled/vector/sublayers/line/Tiled2dMapVectorLineSubLayer.cpp
@@ -276,7 +276,8 @@ Tiled2dMapVectorLineSubLayer::updateTileData(const Tiled2dMapTileInfo &tileInfo,
 
 void Tiled2dMapVectorLineSubLayer::clearTileData(const Tiled2dMapTileInfo &tileInfo) {
     auto mapInterface = this->mapInterface;
-    if (!mapInterface) {
+    auto scheduler = mapInterface ? mapInterface->getScheduler() : nullptr;
+    if (!scheduler) {
         return;
     }
     {
@@ -299,7 +300,7 @@ void Tiled2dMapVectorLineSubLayer::clearTileData(const Tiled2dMapTileInfo &tileI
     }
     if (objectsToClear.empty()) return;
 
-    mapInterface->getScheduler()->addTask(std::make_shared<LambdaTask>(
+    scheduler->addTask(std::make_shared<LambdaTask>(
             TaskConfig("LineGroupTile_clear_" + std::to_string(tileInfo.zoomIdentifier) + "/" + std::to_string(tileInfo.x) + "/" +
                        std::to_string(tileInfo.y), 0, TaskPriority::NORMAL, ExecutionEnvironment::GRAPHICS),
             [objectsToClear] {
@@ -323,7 +324,8 @@ Tiled2dMapVectorLineSubLayer::addLines(const Tiled2dMapTileInfo &tileInfo,
     auto mapInterface = this->mapInterface;
     const auto &objectFactory = mapInterface ? mapInterface->getGraphicsObjectFactory() : nullptr;
     const auto &coordinateConverterHelper = mapInterface ? mapInterface->getCoordinateConverterHelper() : nullptr;
-    if (!objectFactory || !coordinateConverterHelper) {
+    auto scheduler = mapInterface ? mapInterface->getScheduler() : nullptr;
+    if (!objectFactory || !coordinateConverterHelper || !scheduler) {
         return;
     }
 
@@ -358,7 +360,7 @@ Tiled2dMapVectorLineSubLayer::addLines(const Tiled2dMapTileInfo &tileInfo,
 
     std::weak_ptr<Tiled2dMapVectorLineSubLayer> weakSelfPtr = std::dynamic_pointer_cast<Tiled2dMapVectorLineSubLayer>(
             shared_from_this());
-    mapInterface->getScheduler()->addTask(std::make_shared<LambdaTask>(
+    scheduler->addTask(std::make_shared<LambdaTask>(
             TaskConfig("LineLayer_setup", 0, TaskPriority::NORMAL, ExecutionEnvironment::GRAPHICS),
             [weakSelfPtr, tileInfo, newGraphicObjects] {
                 auto selfPtr = weakSelfPtr.lock();

--- a/shared/src/map/layers/tiled/vector/sublayers/polygon/Tiled2dMapVectorPolygonSubLayer.cpp
+++ b/shared/src/map/layers/tiled/vector/sublayers/polygon/Tiled2dMapVectorPolygonSubLayer.cpp
@@ -350,7 +350,8 @@ void Tiled2dMapVectorPolygonSubLayer::update() {
 
 void Tiled2dMapVectorPolygonSubLayer::clearTileData(const Tiled2dMapTileInfo &tileInfo) {
     auto mapInterface = this->mapInterface;
-    if (!mapInterface) { return; }
+    auto scheduler = mapInterface ? mapInterface->getScheduler() : nullptr;
+    if (!scheduler) { return; }
 
     {
         std::lock_guard<std::recursive_mutex> lock(hitDetectionMutex);
@@ -371,7 +372,7 @@ void Tiled2dMapVectorPolygonSubLayer::clearTileData(const Tiled2dMapTileInfo &ti
     }
     if (objectsToClear.empty()) return;
 
-    mapInterface->getScheduler()->addTask(std::make_shared<LambdaTask>(
+    scheduler->addTask(std::make_shared<LambdaTask>(
             TaskConfig("LineGroupTile_clear_" + std::to_string(tileInfo.zoomIdentifier) + "/" + std::to_string(tileInfo.x) + "/" +
                        std::to_string(tileInfo.y), 0, TaskPriority::NORMAL, ExecutionEnvironment::GRAPHICS),
             [objectsToClear] {


### PR DESCRIPTION
Added a dedicated destroy-function to the MapInterface for a proper and explicit teardown, prepared for 1.5.3 release