### PR TITLE
Sprite data in existing subtiles

### DIFF
--- a/shared/src/map/layers/tiled/vector/sourcemanagers/Tiled2dMapVectorSourceTileDataManager.cpp
+++ b/shared/src/map/layers/tiled/vector/sourcemanagers/Tiled2dMapVectorSourceTileDataManager.cpp
@@ -420,14 +420,14 @@ void Tiled2dMapVectorSourceTileDataManager::setSprites(std::shared_ptr<SpriteDat
 
     if (!tiles.empty()) {
         auto selfActor = WeakActor(mailbox, weak_from_this());
-        selfActor.message(MailboxExecutionEnvironment::graphics, &Tiled2dMapVectorSourceTileDataManager::setupExistingTilesWithSprite);
+        selfActor.message(&Tiled2dMapVectorSourceTileDataManager::setupExistingTilesWithSprite);
     }
 }
 
 void Tiled2dMapVectorSourceTileDataManager::setupExistingTilesWithSprite() {
     for (const auto &[tile, subTiles] : tiles) {
         for (const auto &[index, string, actor]: subTiles) {
-            actor.message(&Tiled2dMapVectorTile::setSpriteData, spriteData, spriteTexture);
+            actor.message(MailboxExecutionEnvironment::graphics, &Tiled2dMapVectorTile::setSpriteData, spriteData, spriteTexture);
         }
     }
 

--- a/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSourceSymbolDataManager.cpp
+++ b/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSourceSymbolDataManager.cpp
@@ -282,9 +282,7 @@ void Tiled2dMapVectorSourceSymbolDataManager::setupExistingSymbolWithSprite() {
     for (const auto &[tile, symbolGroupMap]: tileSymbolGroupMap) {
         for (const auto &[layerIdentifier, symbolGroups]: symbolGroupMap) {
             for (auto &symbolGroup: symbolGroups) {
-                symbolGroup.syncAccess([&](auto group){
-                    group->setupObjects(spriteData, spriteTexture);
-                });
+                symbolGroup.message(MailboxExecutionEnvironment::graphics, &Tiled2dMapVectorSymbolGroup::setupObjects, spriteData, spriteTexture);
             }
         }
     }


### PR DESCRIPTION
Correctly schedule the setup of the sprite data in existing subtiles on the graphics thread