### PR TITLE
Vector raster sub-layer identification

### DIFF
--- a/shared/public/LineVectorLayerDescription.h
+++ b/shared/public/LineVectorLayerDescription.h
@@ -125,7 +125,7 @@ public:
     style(style) {};
 
     std::unique_ptr<VectorLayerDescription> clone() override {
-        return std::make_unique<LineVectorLayerDescription>(identifier, source, sourceId, minZoom, maxZoom,
+        return std::make_unique<LineVectorLayerDescription>(identifier, source, sourceLayer, minZoom, maxZoom,
                                                             filter ? filter->clone() : nullptr, style, renderPassIndex,
                                                             interactable ? interactable->clone() : nullptr);
     }

--- a/shared/public/PolygonVectorLayerDescription.h
+++ b/shared/public/PolygonVectorLayerDescription.h
@@ -96,7 +96,7 @@ public:
     style(style) {};
 
     std::unique_ptr<VectorLayerDescription> clone() override {
-        return std::make_unique<PolygonVectorLayerDescription>(identifier, source, sourceId, minZoom, maxZoom,
+        return std::make_unique<PolygonVectorLayerDescription>(identifier, source, sourceLayer, minZoom, maxZoom,
                                                                filter ? filter->clone() : nullptr, style, renderPassIndex,
                                                                interactable ? interactable->clone() : nullptr);
     }

--- a/shared/public/RasterVectorLayerDescription.h
+++ b/shared/public/RasterVectorLayerDescription.h
@@ -109,6 +109,7 @@ public:
     bool underzoom;
 
     RasterVectorLayerDescription(std::string identifier,
+                                 std::string source,
                                  int minZoom,
                                  int maxZoom,
                                  std::string url,
@@ -121,13 +122,14 @@ public:
                                  std::shared_ptr<Value> interactable,
                                  bool underzoom,
                                  bool overzoom):
-    VectorLayerDescription(identifier, identifier, "", minZoom, maxZoom, nullptr, renderPassIndex, interactable),
+    VectorLayerDescription(identifier, source, "", minZoom, maxZoom, nullptr, renderPassIndex, interactable),
     style(style), url(url), underzoom(underzoom), overzoom(overzoom), adaptScaleToScreen(adaptScaleToScreen), numDrawPreviousLayers(numDrawPreviousLayers),
     maskTiles(maskTiles), zoomLevelScaleFactor(zoomLevelScaleFactor) {};
 
 
     std::unique_ptr<VectorLayerDescription> clone() override {
         return std::make_unique<RasterVectorLayerDescription>(identifier,
+                                            source,
                                             minZoom,
                                             maxZoom,
                                             url,

--- a/shared/public/SymbolVectorLayerDescription.h
+++ b/shared/public/SymbolVectorLayerDescription.h
@@ -382,7 +382,7 @@ public:
     style(style) {};
 
     std::unique_ptr<VectorLayerDescription> clone() override {
-        return std::make_unique<SymbolVectorLayerDescription>(identifier, source, sourceId, minZoom, maxZoom,
+        return std::make_unique<SymbolVectorLayerDescription>(identifier, source, sourceLayer, minZoom, maxZoom,
                                                               filter ? filter->clone() : nullptr, style, renderPassIndex,
                                                               interactable ? interactable : nullptr);
     }

--- a/shared/public/Tiled2dMapVectorLayerConfig.h
+++ b/shared/public/Tiled2dMapVectorLayerConfig.h
@@ -47,7 +47,6 @@ public:
     }
 
     std::string getLayerName() override {
-        LogDebug <<= "vector layer config get identifier";
         return description->identifier;
     }
 

--- a/shared/public/Tiled2dMapVectorLayerParserHelper.h
+++ b/shared/public/Tiled2dMapVectorLayerParserHelper.h
@@ -102,6 +102,7 @@ public:
                 }
 
                 rasterLayerMap[key] = std::make_shared<RasterVectorLayerDescription>(layerName,
+                                                                                     key,
                                                                                      minZoom,
                                                                                      maxZoom,
                                                                                      url,
@@ -177,6 +178,7 @@ public:
                 auto layer = rasterLayerMap.at(val["source"]);
 
                 auto newLayer = std::make_shared<RasterVectorLayerDescription>(val["id"],
+                                             val["source"],
                                              val.value("minzoom", layer->minZoom),
                                              val.value("maxzoom", layer->maxZoom),
                                              layer->url,

--- a/shared/public/VectorLayerDescription.h
+++ b/shared/public/VectorLayerDescription.h
@@ -21,7 +21,7 @@ class VectorLayerDescription {
 public:
     std::string identifier;
     std::string source;
-    std::string sourceId;
+    std::string sourceLayer;
     int minZoom;
     int maxZoom;
     std::shared_ptr<Value> filter;
@@ -59,14 +59,14 @@ public:
                            std::shared_ptr<Value> filter,
                            std::optional<int32_t> renderPassIndex,
                            std::shared_ptr<Value> interactable):
-    identifier(identifier),
-    source(source),
-    sourceId(sourceId),
-    minZoom(minZoom),
-    maxZoom(maxZoom),
-    filter(filter),
-    renderPassIndex(renderPassIndex),
-    interactable(interactable) {}
+            identifier(identifier),
+            source(source),
+            sourceLayer(sourceId),
+            minZoom(minZoom),
+            maxZoom(maxZoom),
+            filter(filter),
+            renderPassIndex(renderPassIndex),
+            interactable(interactable) {}
 
     virtual ~VectorLayerDescription() = default;
 

--- a/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayer.cpp
+++ b/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayer.cpp
@@ -246,7 +246,7 @@ void Tiled2dMapVectorLayer::initializeVectorLayer() {
             case line:
             case polygon:
             case custom: {
-                layersToDecode[layerDesc->source].insert(layerDesc->sourceId);
+                layersToDecode[layerDesc->source].insert(layerDesc->sourceLayer);
                 break;
             }
         }
@@ -692,7 +692,7 @@ void Tiled2dMapVectorLayer::updateLayerDescription(std::shared_ptr<VectorLayerDe
 
     // Evaluate if a complete replacement of the tiles is needed (source/zoom adjustments may lead to a different set of created tiles)
     bool needsTileReplace = legacyDescription->source != layerDescription->source
-                            || legacyDescription->sourceId != layerDescription->sourceId
+                            || legacyDescription->sourceLayer != layerDescription->sourceLayer
                             || legacyDescription->minZoom != layerDescription->minZoom
                             || legacyDescription->maxZoom != layerDescription->maxZoom
                             || legacyDescription->filter != layerDescription->filter;

--- a/shared/src/map/layers/tiled/vector/Tiled2dMapVectorRasterSubLayerConfig.h
+++ b/shared/src/map/layers/tiled/vector/Tiled2dMapVectorRasterSubLayerConfig.h
@@ -60,7 +60,7 @@ public:
     }
 
     std::string getLayerName() override {
-        return description->identifier;
+        return description->source;
     }
 
     std::optional<Tiled2dMapVectorSettings> getVectorSettings() override {

--- a/shared/src/map/layers/tiled/vector/sourcemanagers/Tiled2dMapVectorSourceRasterTileDataManager.cpp
+++ b/shared/src/map/layers/tiled/vector/sourcemanagers/Tiled2dMapVectorSourceRasterTileDataManager.cpp
@@ -88,7 +88,7 @@ void Tiled2dMapVectorSourceRasterTileDataManager::onRasterTilesUpdated(const std
 
             for (int32_t index = 0; index < mapDescription->layers.size(); index++) {
                 auto const &layer= mapDescription->layers.at(index);
-                if (layer->getType() != VectorLayerType::raster || layer->identifier != layerName) {
+                if (layer->getType() != VectorLayerType::raster || layer->source != layerName) {
                     continue;
                 }
 

--- a/shared/src/map/layers/tiled/vector/sourcemanagers/Tiled2dMapVectorSourceVectorTileDataManager.cpp
+++ b/shared/src/map/layers/tiled/vector/sourcemanagers/Tiled2dMapVectorSourceVectorTileDataManager.cpp
@@ -95,7 +95,7 @@ void Tiled2dMapVectorSourceVectorTileDataManager::onVectorTilesUpdated(const std
                 if (layer->source != sourceName) {
                     continue;
                 }
-                auto const mapIt = tile->layerFeatureMaps->find(layer->sourceId);
+                auto const mapIt = tile->layerFeatureMaps->find(layer->sourceLayer);
                 if (mapIt == tile->layerFeatureMaps->end()) {
                     continue;
                 }
@@ -173,7 +173,7 @@ void Tiled2dMapVectorSourceVectorTileDataManager::updateLayerDescription(std::sh
                 continue;
             }
 
-            auto const mapIt = tileData.layerFeatureMaps->find(layerDescription->sourceId);
+            auto const mapIt = tileData.layerFeatureMaps->find(layerDescription->sourceLayer);
             if (mapIt == tileData.layerFeatureMaps->end()) {
                 continue;
             }
@@ -208,7 +208,7 @@ void Tiled2dMapVectorSourceVectorTileDataManager::updateLayerDescription(std::sh
         } else {
             for (auto &[index, identifier, tile]  : subTiles->second) {
                 if (identifier == layerDescription->identifier) {
-                    auto const mapIt = tileData.layerFeatureMaps->find(layerDescription->sourceId);
+                    auto const mapIt = tileData.layerFeatureMaps->find(layerDescription->sourceLayer);
                     if (mapIt == tileData.layerFeatureMaps->end()) {
                         break;
                     }

--- a/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSourceSymbolDataManager.cpp
+++ b/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSourceSymbolDataManager.cpp
@@ -117,7 +117,7 @@ void Tiled2dMapVectorSourceSymbolDataManager::updateLayerDescription(std::shared
             continue;
         }
 
-        const auto &dataIt = tileData.layerFeatureMaps->find(layerDescription->sourceId);
+        const auto &dataIt = tileData.layerFeatureMaps->find(layerDescription->sourceLayer);
 
         if (dataIt != tileData.layerFeatureMaps->end()) {
             // there is something in this layer to display
@@ -187,7 +187,7 @@ void Tiled2dMapVectorSourceSymbolDataManager::onVectorTilesUpdated(const std::st
         tileSymbolGroupMap[tile->tileInfo] = {};
 
         for (const auto &[layerIdentifier, layer]: layerDescriptions) {
-            const auto &dataIt = tile->layerFeatureMaps->find(layer->sourceId);
+            const auto &dataIt = tile->layerFeatureMaps->find(layer->sourceLayer);
 
             if (dataIt != tile->layerFeatureMaps->end()) {
                 // there is something in this layer to display

--- a/shared/src/map/layers/tiled/vector/tiles/polygon/Tiled2dMapVectorPolygonPatternTile.cpp
+++ b/shared/src/map/layers/tiled/vector/tiles/polygon/Tiled2dMapVectorPolygonPatternTile.cpp
@@ -151,7 +151,7 @@ void Tiled2dMapVectorPolygonPatternTile::setVectorTileData(const Tiled2dMapVecto
         return;
     }
 
-    const std::string layerName = description->sourceId;
+    const std::string layerName = description->sourceLayer;
     const auto indicesLimit = std::numeric_limits<uint16_t>::max();
 
     if (!tileData->empty()) {

--- a/shared/src/map/layers/tiled/vector/tiles/polygon/Tiled2dMapVectorPolygonTile.cpp
+++ b/shared/src/map/layers/tiled/vector/tiles/polygon/Tiled2dMapVectorPolygonTile.cpp
@@ -129,7 +129,7 @@ void Tiled2dMapVectorPolygonTile::setVectorTileData(const Tiled2dMapVectorTileDa
         return;
     }
 
-    const std::string layerName = description->sourceId;
+    const std::string layerName = description->sourceLayer;
 
     const auto indicesLimit = std::numeric_limits<uint16_t>::max();
 


### PR DESCRIPTION
Rename sourceId to sourceLayer (consistent with style specs), use source name for VectorLayer raster sublayer identification.