### PR TITLE
Set alpha when initializing non-raster vector layer

### DIFF
--- a/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayer.cpp
+++ b/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayer.cpp
@@ -292,6 +292,7 @@ void Tiled2dMapVectorLayer::initializeVectorLayer() {
                                                                                      layerConfig,
                                                                                      source,
                                                                                      vectorSource.weakActor<Tiled2dMapVectorSource>());
+        sourceManagerActor.unsafe()->setAlpha(alpha);
         sourceTileManagers[source] = sourceManagerActor.strongActor<Tiled2dMapVectorSourceTileDataManager>();
         interactionDataManagers[source].push_back(sourceManagerActor.weakActor<Tiled2dMapVectorSourceDataManager>());
 


### PR DESCRIPTION
When inserting a vector layer from a style.json and setting the alpha immediately afterwards, this change has no effect because the source manager is initialized after the call to `setAlpha` and does not set the alpha during initialization like for a raster layer.