### PR TITLE
Crash-Fix

### DIFF
--- a/ios/graphics/Pipelines/PipelineLibrary.swift
+++ b/ios/graphics/Pipelines/PipelineLibrary.swift
@@ -98,7 +98,10 @@ public struct Pipeline: Codable, CaseIterable {
 
     public var json: String {
         do {
-            let jsonData = try JSONEncoder().encode(self)
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = .sortedKeys
+
+            let jsonData = try encoder.encode(self)
 
             guard let jsonString = String(data: jsonData, encoding: .utf8) else {
                 fatalError("unable to encode Pipeline")


### PR DESCRIPTION
- iOS 17 Crash, mitJson-Encoder wird verschieden sortiert und dann crashed StaticMetalLibrary