### PR TITLE
make sure that at least 8 threads are created

### DIFF
--- a/shared/src/map/scheduling/ThreadPoolSchedulerImpl.cpp
+++ b/shared/src/map/scheduling/ThreadPoolSchedulerImpl.cpp
@@ -18,7 +18,7 @@ std::shared_ptr<SchedulerInterface> ThreadPoolScheduler::create(const std::share
 ThreadPoolSchedulerImpl::ThreadPoolSchedulerImpl(const std::shared_ptr<ThreadPoolCallbacks> &callbacks)
         : callbacks(callbacks), separateGraphicsQueue(false), delayedTaskThread(&ThreadPoolSchedulerImpl::delayedTasksThread, this), nextWakeup(std::chrono::system_clock::now() + std::chrono::seconds(1)) {
     unsigned int maxNumThreads = std::thread::hardware_concurrency();
-    if (maxNumThreads < 1) maxNumThreads = DEFAULT_MAX_NUM_THREADS;
+    if (maxNumThreads < DEFAULT_MIN_NUM_THREADS) maxNumThreads = DEFAULT_MIN_NUM_THREADS;
     for (std::size_t i = 0u; i < maxNumThreads; ++i) {
         threads.emplace_back(makeSchedulerThread(i, TaskPriority::NORMAL));
     }

--- a/shared/src/map/scheduling/ThreadPoolSchedulerImpl.h
+++ b/shared/src/map/scheduling/ThreadPoolSchedulerImpl.h
@@ -63,7 +63,7 @@ private:
     std::mutex graphicsMutex;
 
     std::deque<std::shared_ptr<TaskInterface>> graphicsQueue;
-    static const uint8_t DEFAULT_MAX_NUM_THREADS = 8;
+    static const uint8_t DEFAULT_MIN_NUM_THREADS = 8;
     std::vector<std::thread> threads;
 
     using TimeStamp = std::chrono::time_point<std::chrono::system_clock>;


### PR DESCRIPTION
otherwise it is easy to run into a deadlock with devices with 2 concurrent threads