### PR TITLE
Allow Rotation for Stretch Icons

### DIFF
--- a/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSymbolObject.cpp
+++ b/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSymbolObject.cpp
@@ -508,16 +508,12 @@ void Tiled2dMapVectorSymbolObject::updateStretchIconProperties(std::vector<float
     double textHeight = 0.0;
 
     if (labelObject) {
-         textWidth = labelObject->dimensions.x + (leftPadding + rightPadding);
+        textWidth = labelObject->dimensions.x + (leftPadding + rightPadding);
         textHeight = labelObject->dimensions.y + (topPadding + bottomPadding);
     }
 
-    if (description->identifier == "stop_location_rotation_flat") {
-        printf("stop_location_rotation_flat");
-    }
-
-    auto scaleX = std::max(1.0, textWidth / (spriteWidth * iconSize));
-    auto scaleY = std::max(1.0, textHeight / (spriteHeight * iconSize));
+    const auto scaleX = std::max(1.0, textWidth / (spriteWidth * iconSize));
+    const auto scaleY = std::max(1.0, textHeight / (spriteHeight * iconSize));
 
     if (iconTextFit == IconTextFit::WIDTH || iconTextFit == IconTextFit::BOTH) {
         spriteWidth *= scaleX;

--- a/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSymbolObject.cpp
+++ b/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSymbolObject.cpp
@@ -488,8 +488,10 @@ void Tiled2dMapVectorSymbolObject::updateStretchIconProperties(std::vector<float
 
     isStretchIconOpaque = alphas[countOffset] == 0;
 
+    rotations[countOffset] = iconRotate;
+
     if (lastIconUpdateRotation != rotation && iconRotationAlignment != SymbolAlignment::MAP) {
-        rotations[countOffset] = rotation;
+        rotations[countOffset] += rotation;
     }
 
     const double densityOffset = (camera->getScreenDensityPpi() / 160.0) / stretchSpriteInfo->pixelRatio;
@@ -502,8 +504,17 @@ void Tiled2dMapVectorSymbolObject::updateStretchIconProperties(std::vector<float
     const float bottomPadding = iconTextFitPadding[2] * stretchSpriteInfo->pixelRatio * densityOffset * scaleFactor;
     const float leftPadding = iconTextFitPadding[3] * stretchSpriteInfo->pixelRatio * densityOffset * scaleFactor;
 
-    const auto textWidth = labelObject->dimensions.x + (leftPadding + rightPadding);
-    const auto textHeight = labelObject->dimensions.y + (topPadding + bottomPadding);
+    double textWidth = 0.0;
+    double textHeight = 0.0;
+
+    if (labelObject) {
+         textWidth = labelObject->dimensions.x + (leftPadding + rightPadding);
+        textHeight = labelObject->dimensions.y + (topPadding + bottomPadding);
+    }
+
+    if (description->identifier == "stop_location_rotation_flat") {
+        printf("stop_location_rotation_flat");
+    }
 
     auto scaleX = std::max(1.0, textWidth / (spriteWidth * iconSize));
     auto scaleY = std::max(1.0, textHeight / (spriteHeight * iconSize));


### PR DESCRIPTION
Swisstopo kombiniert in einem Layer Stretch-Icons und rotirte Icons.

Damit das funktioniert, wird mit diesem Change die Rotation auch in `updateStretchIconProperties` gesetzt.
`{
      "id": "stop_location_rotation_flat",
      "type": "symbol",
      "source": "78a2de85-ca3c-4b41-b9a3-1ced5da8bcf0",
      "source-layer": "poi",
      "minzoom": 14,
      "maxzoom": 22,
      "layout": {
        "icon-size": ["interpolate", ["linear"], ["zoom"], 13, 0.2, 18, 0.4],
        "text-font": ["Frutiger Neue Condensed Regular"],
        "icon-image": [
          "case",
          ["has", "direction"],
          "blue_round_arrow",
          "blue_round_white_dot"
        ],
        "visibility": "visible",
        "icon-rotate": ["to-number", ["get", "direction"]],
        "icon-text-fit": "width",
        "symbol-placement": "point",
        "icon-allow-overlap": true,
        "text-allow-overlap": true,
        "icon-pitch-alignment": "map",
        "icon-rotation-alignment": "map"
      },
      "paint": {
        "icon-color": "rgba(34, 39, 105, 1)",
        "text-color": "rgb(255,255,255)",
        "text-halo-blur": 0,
        "text-halo-width": 0
      },
      "filter": [
        "all",
        ["in", "subclass", "stop_position", "platform"],
        ["!has", "name"],
        ["==", "station_id", ""]
      ]
    }` 