### PR TITLE
Remove old texture in Quad2dOpenGl before loading in a new one

### DIFF
--- a/android/src/main/cpp/graphics/objects/Quad2dOpenGl.cpp
+++ b/android/src/main/cpp/graphics/objects/Quad2dOpenGl.cpp
@@ -138,6 +138,10 @@ void Quad2dOpenGl::removeTextureCoordsGlBuffers() {
 void Quad2dOpenGl::loadTexture(const std::shared_ptr<::RenderingContextInterface> &context,
                                const std::shared_ptr<TextureHolderInterface> &textureHolder) {
     std::lock_guard<std::recursive_mutex> lock(dataMutex);
+    if (this->textureHolder != nullptr) {
+        removeTexture();
+    }
+
     if (textureHolder != nullptr) {
         texturePointer = textureHolder->attachToGraphics();
 

--- a/android/src/main/cpp/graphics/objects/Quad2dOpenGl.cpp
+++ b/android/src/main/cpp/graphics/objects/Quad2dOpenGl.cpp
@@ -81,19 +81,17 @@ void Quad2dOpenGl::prepareGlData(int program) {
     glUseProgram(program);
 
     positionHandle = glGetAttribLocation(program, "vPosition");
-    if (glDataBuffersGenerated) {
-        glDeleteBuffers(1, &vertexBuffer);
+    if (!glDataBuffersGenerated) {
+        glGenBuffers(1, &vertexBuffer);
     }
-    glGenBuffers(1, &vertexBuffer);
     glBindBuffer(GL_ARRAY_BUFFER, vertexBuffer);
     glBufferData(GL_ARRAY_BUFFER, sizeof(GLfloat) * vertices.size(), &vertices[0], GL_STATIC_DRAW);
 
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 
-    if (glDataBuffersGenerated) {
-        glDeleteBuffers(1, &indexBuffer);
+    if (!glDataBuffersGenerated) {
+        glGenBuffers(1, &indexBuffer);
     }
-    glGenBuffers(1, &indexBuffer);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexBuffer);
     glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte) * indices.size(), &indices[0], GL_STATIC_DRAW);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
@@ -126,6 +124,7 @@ void Quad2dOpenGl::prepareTextureCoordsGlData(int program) {
 void Quad2dOpenGl::removeGlBuffers() {
     glDeleteBuffers(1, &vertexBuffer);
     glDeleteBuffers(1, &indexBuffer);
+    glDataBuffersGenerated = false;
 }
 
 void Quad2dOpenGl::removeTextureCoordsGlBuffers() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved texture management in graphics rendering to ensure old textures are properly removed before loading new ones. This may enhance performance and visual fidelity in the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->