### PR TITLE
min/max for geojson tiling

### DIFF
--- a/shared/public/GeoJsonTypes.h
+++ b/shared/public/GeoJsonTypes.h
@@ -80,6 +80,7 @@ public:
     virtual const GeoJSONTileInterface& getTile(const uint8_t z, const uint32_t x_, const uint32_t y) = 0;
     virtual bool isLoaded() = 0;
     virtual void waitIfNotLoaded(std::shared_ptr<::djinni::Promise<std::shared_ptr<DataLoaderResult>>> promise) = 0;
+    virtual uint8_t getMinZoom() = 0;
     virtual uint8_t getMaxZoom() = 0;
     virtual void reload(const std::vector<std::shared_ptr<::LoaderInterface>> &loaders) = 0;
     virtual void reload(const std::shared_ptr<GeoJson> &geoJson) = 0;

--- a/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayerParserHelper.cpp
+++ b/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayerParserHelper.cpp
@@ -180,11 +180,19 @@ Tiled2dMapVectorLayerParserResult Tiled2dMapVectorLayerParserHelper::parseStyleJ
             tileJsons[key] = val;
         } else if (type == "geojson") {
             nlohmann::json geojson;
+            Options options;
+
+            if (val["minzoom"].is_number_integer()) {
+                options.minZoom = val["minzoom"].get<u_int8_t>();
+            }
+            if (val["maxzoom"].is_number_integer()) {
+                options.maxZoom = val["maxzoom"].get<int>();
+            }
             if (val["data"].is_string()) {
-                geojsonSources[key] = GeoJsonVTFactory::getGeoJsonVt(key, replaceUrlParams(val["data"].get<std::string>(), sourceUrlParams), loaders, localDataProvider);
+                geojsonSources[key] = GeoJsonVTFactory::getGeoJsonVt(key, replaceUrlParams(val["data"].get<std::string>(), sourceUrlParams), loaders, localDataProvider, options);
             } else {
                 assert(val["data"].is_object());
-                geojsonSources[key] = GeoJsonVTFactory::getGeoJsonVt(GeoJsonParser::getGeoJson(val["data"]));
+                geojsonSources[key] = GeoJsonVTFactory::getGeoJsonVt(GeoJsonParser::getGeoJson(val["data"]), options);
             }
         }
     }

--- a/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayerParserHelper.cpp
+++ b/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayerParserHelper.cpp
@@ -183,10 +183,10 @@ Tiled2dMapVectorLayerParserResult Tiled2dMapVectorLayerParserHelper::parseStyleJ
             Options options;
 
             if (val["minzoom"].is_number_integer()) {
-                options.minZoom = val["minzoom"].get<u_int8_t>();
+                options.minZoom = val["minzoom"].get<uint8_t>();
             }
             if (val["maxzoom"].is_number_integer()) {
-                options.maxZoom = val["maxzoom"].get<int>();
+                options.maxZoom = val["maxzoom"].get<uint8_t>();
             }
             if (val["data"].is_string()) {
                 geojsonSources[key] = GeoJsonVTFactory::getGeoJsonVt(key, replaceUrlParams(val["data"].get<std::string>(), sourceUrlParams), loaders, localDataProvider, options);

--- a/shared/src/map/layers/tiled/vector/geojson/GeoJsonVTFactory.h
+++ b/shared/src/map/layers/tiled/vector/geojson/GeoJsonVTFactory.h
@@ -17,12 +17,14 @@
 
 class GeoJsonVTFactory {
 public:
-    static std::shared_ptr<GeoJSONVTInterface> getGeoJsonVt(const std::shared_ptr<GeoJson> &geoJson) {
-        return std::static_pointer_cast<GeoJSONVTInterface>(std::make_shared<GeoJSONVT>(geoJson));
+    static std::shared_ptr<GeoJSONVTInterface> getGeoJsonVt(const std::shared_ptr<GeoJson> &geoJson,
+                                                            const Options& options = Options()) {
+        return std::static_pointer_cast<GeoJSONVTInterface>(std::make_shared<GeoJSONVT>(geoJson, options));
     }
 
-    static std::shared_ptr<GeoJSONVTInterface> getGeoJsonVt(const std::string &sourceName, const std::string &geoJsonUrl, const std::vector<std::shared_ptr<::LoaderInterface>> &loaders, const std::shared_ptr<Tiled2dMapVectorLayerLocalDataProviderInterface> &localDataProvider) {
-        std::shared_ptr<GeoJSONVT> vt = std::make_shared<GeoJSONVT>(sourceName, geoJsonUrl, loaders, localDataProvider);
+    static std::shared_ptr<GeoJSONVTInterface> getGeoJsonVt(const std::string &sourceName, const std::string &geoJsonUrl, const std::vector<std::shared_ptr<::LoaderInterface>> &loaders, const std::shared_ptr<Tiled2dMapVectorLayerLocalDataProviderInterface> &localDataProvider,
+                                                            const Options& options = Options()) {
+        std::shared_ptr<GeoJSONVT> vt = std::make_shared<GeoJSONVT>(sourceName, geoJsonUrl, loaders, localDataProvider, options);
         vt->load();
         return vt;
     }

--- a/shared/src/map/layers/tiled/vector/geojson/geojsonvt/geojsonvt.hpp
+++ b/shared/src/map/layers/tiled/vector/geojson/geojsonvt/geojsonvt.hpp
@@ -26,6 +26,9 @@ struct TileOptions {
 };
 
 struct Options : TileOptions {
+    // min zoom to will be visible
+    uint8_t minZoom = 0;
+
     // max zoom to preserve detail on
     uint8_t maxZoom = 18;
 
@@ -53,7 +56,7 @@ public:
         // If the GeoJSON contains only points, there is no need to split it into smaller tiles,
         // as there are no opportunities for simplification, merging, or meaningful point reduction.
         if (geoJson->hasOnlyPoints) {
-            options.maxZoom = 0;
+            options.maxZoom = options.minZoom;
         }
 
 
@@ -114,7 +117,7 @@ public:
                         // If the GeoJSON contains only points, there is no need to split it into smaller tiles,
                         // as there are no opportunities for simplification, merging, or meaningful point reduction.
                         if (geoJson->hasOnlyPoints) {
-                            self->options.maxZoom = 0;
+                            self->options.maxZoom = self->options.minZoom;
                         } else {
                             self->options.maxZoom = 18;
                         }
@@ -150,6 +153,10 @@ public:
         }
     }
 
+    uint8_t getMinZoom() override {
+        return options.minZoom;
+    }
+
     uint8_t getMaxZoom() override {
         return options.maxZoom;
     }
@@ -167,7 +174,7 @@ public:
         // If the GeoJSON contains only points, there is no need to split it into smaller tiles,
         // as there are no opportunities for simplification, merging, or meaningful point reduction.
         if (geoJson->hasOnlyPoints) {
-            options.maxZoom = 0;
+            options.maxZoom = options.minZoom;
         } else {
             options.maxZoom = 18;
         }
@@ -317,6 +324,11 @@ private:
         
         // if we sliced further down, no need to keep source geometry
         tile.source_features.clear();
+
+        if (z < options.minZoom) {
+            // if z smaller than min zoom, no need to keep tile
+            tiles.erase(it);
+        }
     }
 
     void resolveAllWaitingPromises() {

--- a/shared/src/map/layers/tiled/vector/geojson/geojsonvt/geojsonvt.hpp
+++ b/shared/src/map/layers/tiled/vector/geojson/geojsonvt/geojsonvt.hpp
@@ -278,9 +278,11 @@ private:
         
         auto& tile = it->second;
         
-        if (geometries.empty())
+        if (geometries.empty()) {
+            tiles.erase(it);
             return;
-        
+        }
+
         //if it's the first-pass tiling
         if (cz == 0u) {
             // stop tiling if we reached max zoom, or if the tile is too simple


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to specify minimum zoom levels for GeoJSON data layers.

- **Enhancements**
  - Enabled handling of zoom level properties for better map layer customization.

- **Bug Fixes**
  - Corrected zoom level assignments to ensure consistent map rendering based on data type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->