### PR TITLE
only set hidden if inside collision grid

### DIFF
--- a/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSymbolObject.cpp
+++ b/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSymbolObject.cpp
@@ -861,7 +861,10 @@ void Tiled2dMapVectorSymbolObject::collisionDetection(const double zoomIdentifie
         }
     }
 
-    setHideFromCollision(willCollide || outside);
+    if (!outside) {
+        setHideFromCollision(willCollide);
+    }
+
 }
 
 std::optional<std::tuple<Coord, VectorLayerFeatureInfo>> Tiled2dMapVectorSymbolObject::onClickConfirmed(const CircleD &clickHitCircle) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved logic to ensure map symbols are only hidden from collision when necessary, enhancing map readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->