### PR TITLE
Don't replace vector layer tile updates

### DIFF
--- a/shared/src/map/layers/tiled/vector/Tiled2dMapVectorSource.cpp
+++ b/shared/src/map/layers/tiled/vector/Tiled2dMapVectorSource.cpp
@@ -87,7 +87,7 @@ Tiled2dMapVectorTileInfo::FeatureMap Tiled2dMapVectorSource::postLoadingTask(con
 }
 
 void Tiled2dMapVectorSource::notifyTilesUpdates() {
-    listener.message(MailboxDuplicationStrategy::replaceNewest, &Tiled2dMapVectorSourceListener::onTilesUpdated, sourceName, getCurrentTiles());
+    listener.message(&Tiled2dMapVectorSourceListener::onTilesUpdated, sourceName, getCurrentTiles());
 }
 
 std::unordered_set<Tiled2dMapVectorTileInfo> Tiled2dMapVectorSource::getCurrentTiles() {

--- a/shared/src/map/layers/tiled/vector/geojson/Tiled2dVectorGeoJsonSource.h
+++ b/shared/src/map/layers/tiled/vector/geojson/Tiled2dVectorGeoJsonSource.h
@@ -57,7 +57,7 @@ public:
     }
 
     virtual void notifyTilesUpdates() override {
-        listener.message(MailboxDuplicationStrategy::replaceNewest, &Tiled2dMapVectorSourceListener::onTilesUpdated, sourceName, getCurrentTiles());
+        listener.message(&Tiled2dMapVectorSourceListener::onTilesUpdated, sourceName, getCurrentTiles());
     };
 
     void didLoad(uint8_t maxZoom) override {


### PR DESCRIPTION
(colliding with multiple sources)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the tile update notification mechanism in map vector sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->