### PR TITLE
Restrict camera to bounds when zooming with tap and move

### DIFF
--- a/shared/src/map/camera/MapCamera2d.cpp
+++ b/shared/src/map/camera/MapCamera2d.cpp
@@ -494,6 +494,7 @@ bool MapCamera2d::onMove(const Vec2F &deltaScreen, bool confirmed, bool doubleCl
         double newZoom = zoom * (1.0 - (deltaScreen.y * 0.003));
 
         zoom = std::max(std::min(newZoom, zoomMin), zoomMax);
+        clampCenterToPaddingCorrectedBounds();
 
         notifyListeners(ListenerType::BOUNDS | ListenerType::MAP_INTERACTION);
         mapInterface->invalidate();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved map navigation by ensuring the camera center stays within the corrected bounds after zoom adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->