### PR TITLE
Keep geojson feature ids optional

### DIFF
--- a/shared/src/map/layers/tiled/vector/geojson/GeoJsonParser.h
+++ b/shared/src/map/layers/tiled/vector/geojson/GeoJsonParser.h
@@ -87,7 +87,7 @@ public:
 
             const auto &properties = parseProperties(feature["properties"]);
 
-            if(feature["id"].is_string()) {
+            if(feature.contains("id") && feature["id"].is_string()) {
                 geometry->featureContext = std::make_shared<FeatureContext>(geomType, properties, feature["id"].get<std::string>());
             } else {
                 geometry->featureContext = std::make_shared<FeatureContext>(geomType, properties, generator.generateUUID());
@@ -124,7 +124,7 @@ public:
                 continue;
             }
 
-            if(!feature["id"].is_string()) {
+            if(!feature.contains("id") || !feature["id"].is_string()) {
                 continue;
             }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the handling of the "id" field in GeoJSON features to enhance parsing robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->