### PR TITLE
Fixes readyness of textured quad2d metal instance

### DIFF
--- a/ios/graphics/Helpers/MTLDevice+Helpers.swift
+++ b/ios/graphics/Helpers/MTLDevice+Helpers.swift
@@ -15,7 +15,7 @@ import UIKit
 extension MTLDevice {
     func makeBuffer(from sharedBytes: MCSharedBytes) -> MTLBuffer? {
         guard let pointer = UnsafeRawPointer(bitPattern: Int(sharedBytes.address)),
-              sharedBytes.elementCount >= 0
+              sharedBytes.elementCount > 0
         else { return nil }
 
         return self.makeBuffer(bytes: pointer, length: Int(sharedBytes.elementCount * sharedBytes.bytesPerElement), options: [])

--- a/ios/graphics/Model/Quad/Quad2dInstanced.swift
+++ b/ios/graphics/Model/Quad/Quad2dInstanced.swift
@@ -238,7 +238,6 @@ extension Quad2dInstanced: MCQuad2dInstancedInterface {
         }
         lock.withCritical {
             texture = textureHolder.texture
-            ready = true
         }
     }
 


### PR DESCRIPTION
- "ready" nicht selber setzen, sonst wird setup() nicht komplett aufgerufen und das frame ist nicht gesetzt
- Wwenn instanceCount = 0 ist, gibt es einen Crash beim Erstellen darum ">=" zu ">"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the buffer creation process in the graphics module for better performance.
	- Fixed an issue with texture initialization in the Quad2d model, enhancing stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->