### PR TITLE
Don’t call setZoom during moveToCenter(animated)

### DIFF
--- a/shared/src/map/camera/MapCamera2d.cpp
+++ b/shared/src/map/camera/MapCamera2d.cpp
@@ -95,7 +95,17 @@ void MapCamera2d::moveToCenterPositionZoom(const ::Coord &centerPosition, double
                 this->coordAnimation = nullptr;
             });
         coordAnimation->start();
-        setZoom(adjustedZoom, true);
+        double targetZoom = std::clamp(zoom, zoomMax, zoomMin);
+        zoomAnimation = std::make_shared<DoubleAnimation>(
+              DEFAULT_ANIM_LENGTH, this->zoom, targetZoom, InterpolatorFunction::EaseIn,
+              [=](double zoom) {
+                  this->zoom = zoom;
+              },
+              [=] {
+                  this->zoom = targetZoom;
+                  this->zoomAnimation = nullptr;
+              });
+        zoomAnimation->start();
         mapInterface->invalidate();
     } else {
         this->centerPosition = targetPosition;


### PR DESCRIPTION
setZoom will update centerPosition with wrong logic for that usecase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced smooth zoom animation for the map, enhancing visual transitions when adjusting the zoom level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->