### PR TITLE
return static value without locking

### DIFF
--- a/shared/public/Value.h
+++ b/shared/public/Value.h
@@ -44,7 +44,6 @@
 #include "ValueKeys.h"
 #include <mutex>
 #include <iomanip>
-#include <shared_mutex>
 #include <atomic>
 
 


### PR DESCRIPTION
- this improves evaluation time of static expression
It should still be thread save since isStatic is set atomically after the staticValue is set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved thread safety and static value evaluation in value handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->