### PR TITLE
Mailbox: compare instead of hashing member functions

### DIFF
--- a/shared/public/Tiled2dMapSourceImpl.h
+++ b/shared/public/Tiled2dMapSourceImpl.h
@@ -11,7 +11,6 @@
 #include "DateHelper.h"
 #include "Tiled2dMapSource.h"
 #include "TiledLayerError.h"
-#include <algorithm>
 
 #include "Logger.h"
 #include "Matrix.h"
@@ -19,7 +18,10 @@
 #include "Vec2DHelper.h"
 #include "Vec3DHelper.h"
 #include "gpc.h"
+
+#include <algorithm>
 #include <iostream>
+#include <queue>
 
 struct VisibleTileCandidate {
     int x;


### PR DESCRIPTION
Fix same issue as #658, but use a dynamic cast and a simple comparison instead of attempting to hash a member function pointer.

Also, make it explicit that AskMessage does not support the replaceNew (de)duplication-strategy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced memory management for message handling with weak pointers.
	- Improved tile visibility management in response to camera changes and zoom adjustments.
	- New methods for managing zoom levels, pausing/resuming tile loading, and error management.

- **Bug Fixes**
	- Refined error handling for tile loading failures.

- **Documentation**
	- Updated method signatures for clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->