### PR TITLE
MAP-16: Only render what's visible

### DIFF
--- a/bridging/android/java/io/openmobilemaps/mapscore/shared/graphics/RenderObjectInterface.kt
+++ b/bridging/android/java/io/openmobilemaps/mapscore/shared/graphics/RenderObjectInterface.kt
@@ -16,6 +16,10 @@ abstract class RenderObjectInterface {
 
     abstract fun getCustomModelMatrix(): ArrayList<Float>
 
+    abstract fun setHidden(hidden: Boolean)
+
+    abstract fun isHidden(): Boolean
+
     public class CppProxy : RenderObjectInterface {
         private val nativeRef: Long
         private val destroyed: AtomicBoolean = AtomicBoolean(false)
@@ -54,5 +58,17 @@ abstract class RenderObjectInterface {
             return native_getCustomModelMatrix(this.nativeRef)
         }
         private external fun native_getCustomModelMatrix(_nativeRef: Long): ArrayList<Float>
+
+        override fun setHidden(hidden: Boolean) {
+            assert(!this.destroyed.get()) { error("trying to use a destroyed object") }
+            native_setHidden(this.nativeRef, hidden)
+        }
+        private external fun native_setHidden(_nativeRef: Long, hidden: Boolean)
+
+        override fun isHidden(): Boolean {
+            assert(!this.destroyed.get()) { error("trying to use a destroyed object") }
+            return native_isHidden(this.nativeRef)
+        }
+        private external fun native_isHidden(_nativeRef: Long): Boolean
     }
 }

--- a/bridging/android/jni/graphics/NativeRenderObjectInterface.cpp
+++ b/bridging/android/jni/graphics/NativeRenderObjectInterface.cpp
@@ -47,6 +47,22 @@ std::vector<float> NativeRenderObjectInterface::JavaProxy::getCustomModelMatrix(
     ::djinni::jniExceptionCheck(jniEnv);
     return ::djinni::List<::djinni::F32>::toCpp(jniEnv, jret);
 }
+void NativeRenderObjectInterface::JavaProxy::setHidden(bool c_hidden) {
+    auto jniEnv = ::djinni::jniGetThreadEnv();
+    ::djinni::JniLocalScope jscope(jniEnv, 10);
+    const auto& data = ::djinni::JniClass<::djinni_generated::NativeRenderObjectInterface>::get();
+    jniEnv->CallVoidMethod(Handle::get().get(), data.method_setHidden,
+                           ::djinni::get(::djinni::Bool::fromCpp(jniEnv, c_hidden)));
+    ::djinni::jniExceptionCheck(jniEnv);
+}
+bool NativeRenderObjectInterface::JavaProxy::isHidden() {
+    auto jniEnv = ::djinni::jniGetThreadEnv();
+    ::djinni::JniLocalScope jscope(jniEnv, 10);
+    const auto& data = ::djinni::JniClass<::djinni_generated::NativeRenderObjectInterface>::get();
+    auto jret = jniEnv->CallBooleanMethod(Handle::get().get(), data.method_isHidden);
+    ::djinni::jniExceptionCheck(jniEnv);
+    return ::djinni::Bool::toCpp(jniEnv, jret);
+}
 
 CJNIEXPORT void JNICALL Java_io_openmobilemaps_mapscore_shared_graphics_RenderObjectInterface_00024CppProxy_nativeDestroy(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef)
 {
@@ -88,6 +104,23 @@ CJNIEXPORT jobject JNICALL Java_io_openmobilemaps_mapscore_shared_graphics_Rende
         const auto& ref = ::djinni::objectFromHandleAddress<::RenderObjectInterface>(nativeRef);
         auto r = ref->getCustomModelMatrix();
         return ::djinni::release(::djinni::List<::djinni::F32>::fromCpp(jniEnv, r));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
+}
+
+CJNIEXPORT void JNICALL Java_io_openmobilemaps_mapscore_shared_graphics_RenderObjectInterface_00024CppProxy_native_1setHidden(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jboolean j_hidden)
+{
+    try {
+        const auto& ref = ::djinni::objectFromHandleAddress<::RenderObjectInterface>(nativeRef);
+        ref->setHidden(::djinni::Bool::toCpp(jniEnv, j_hidden));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
+}
+
+CJNIEXPORT jboolean JNICALL Java_io_openmobilemaps_mapscore_shared_graphics_RenderObjectInterface_00024CppProxy_native_1isHidden(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef)
+{
+    try {
+        const auto& ref = ::djinni::objectFromHandleAddress<::RenderObjectInterface>(nativeRef);
+        auto r = ref->isHidden();
+        return ::djinni::release(::djinni::Bool::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }
 

--- a/bridging/android/jni/graphics/NativeRenderObjectInterface.h
+++ b/bridging/android/jni/graphics/NativeRenderObjectInterface.h
@@ -37,6 +37,8 @@ private:
         bool hasCustomModelMatrix() override;
         bool isScreenSpaceCoords() override;
         std::vector<float> getCustomModelMatrix() override;
+        void setHidden(bool hidden) override;
+        bool isHidden() override;
 
     private:
         friend ::djinni::JniInterface<::RenderObjectInterface, ::djinni_generated::NativeRenderObjectInterface>;
@@ -47,6 +49,8 @@ private:
     const jmethodID method_hasCustomModelMatrix { ::djinni::jniGetMethodID(clazz.get(), "hasCustomModelMatrix", "()Z") };
     const jmethodID method_isScreenSpaceCoords { ::djinni::jniGetMethodID(clazz.get(), "isScreenSpaceCoords", "()Z") };
     const jmethodID method_getCustomModelMatrix { ::djinni::jniGetMethodID(clazz.get(), "getCustomModelMatrix", "()Ljava/util/ArrayList;") };
+    const jmethodID method_setHidden { ::djinni::jniGetMethodID(clazz.get(), "setHidden", "(Z)V") };
+    const jmethodID method_isHidden { ::djinni::jniGetMethodID(clazz.get(), "isHidden", "()Z") };
 };
 
 } // namespace djinni_generated

--- a/bridging/ios/MCRenderObjectInterface+Private.mm
+++ b/bridging/ios/MCRenderObjectInterface+Private.mm
@@ -60,6 +60,19 @@ static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for th
     } DJINNI_TRANSLATE_EXCEPTIONS()
 }
 
+- (void)setHidden:(BOOL)hidden {
+    try {
+        _cppRefHandle.get()->setHidden(::djinni::Bool::toCpp(hidden));
+    } DJINNI_TRANSLATE_EXCEPTIONS()
+}
+
+- (BOOL)isHidden {
+    try {
+        auto objcpp_result_ = _cppRefHandle.get()->isHidden();
+        return ::djinni::Bool::fromCpp(objcpp_result_);
+    } DJINNI_TRANSLATE_EXCEPTIONS()
+}
+
 namespace djinni_generated {
 
 class RenderObjectInterface::ObjcProxy final
@@ -95,6 +108,19 @@ public:
         @autoreleasepool {
             auto objcpp_result_ = [djinni_private_get_proxied_objc_object() getCustomModelMatrix];
             return ::djinni::List<::djinni::F32>::toCpp(objcpp_result_);
+        }
+    }
+    void setHidden(bool c_hidden) override
+    {
+        @autoreleasepool {
+            [djinni_private_get_proxied_objc_object() setHidden:(::djinni::Bool::fromCpp(c_hidden))];
+        }
+    }
+    bool isHidden() override
+    {
+        @autoreleasepool {
+            auto objcpp_result_ = [djinni_private_get_proxied_objc_object() isHidden];
+            return ::djinni::Bool::toCpp(objcpp_result_);
         }
     }
 };

--- a/bridging/ios/MCRenderObjectInterface.h
+++ b/bridging/ios/MCRenderObjectInterface.h
@@ -15,4 +15,8 @@
 
 - (nonnull NSArray<NSNumber *> *)getCustomModelMatrix;
 
+- (void)setHidden:(BOOL)hidden;
+
+- (BOOL)isHidden;
+
 @end

--- a/djinni/graphics/core.djinni
+++ b/djinni/graphics/core.djinni
@@ -58,6 +58,8 @@ render_object_interface = interface +c +j +o {
     has_custom_model_matrix() : bool;
     is_screen_space_coords() : bool;
     get_custom_model_matrix() : list<f32>;
+    set_hidden(hidden: bool);
+    is_hidden(): bool;
 }
 
 render_pass_interface = interface +c +j +o {

--- a/shared/public/RenderObject.h
+++ b/shared/public/RenderObject.h
@@ -29,10 +29,15 @@ public:
     virtual std::vector<float> getCustomModelMatrix() override;
 
     virtual bool isScreenSpaceCoords() override;
-    
+
+    virtual void setHidden(bool hidden) override;
+
+    virtual bool isHidden() override;
+
 private:
     std::shared_ptr<GraphicsObjectInterface> graphicsObject;
     bool setCustomModelMatrix = false;
     bool screenSpaceCoords = false;
     std::vector<float> modelMatrix;
+    bool hidden = false;
 };

--- a/shared/public/RenderObjectInterface.h
+++ b/shared/public/RenderObjectInterface.h
@@ -18,4 +18,8 @@ public:
     virtual bool isScreenSpaceCoords() = 0;
 
     virtual std::vector<float> getCustomModelMatrix() = 0;
+
+    virtual void setHidden(bool hidden) = 0;
+
+    virtual bool isHidden() = 0;
 };

--- a/shared/src/graphics/RenderObject.cpp
+++ b/shared/src/graphics/RenderObject.cpp
@@ -27,3 +27,11 @@ bool RenderObject::hasCustomModelMatrix() { return setCustomModelMatrix; }
 std::vector<float> RenderObject::getCustomModelMatrix() { return modelMatrix; }
 
 bool RenderObject::isScreenSpaceCoords() { return screenSpaceCoords; }
+
+void RenderObject::setHidden(bool _hidden) {
+    hidden = _hidden;
+}
+
+bool RenderObject::isHidden() {
+    return hidden;
+}

--- a/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayerParserHelper.cpp
+++ b/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayerParserHelper.cpp
@@ -210,6 +210,41 @@ Tiled2dMapVectorLayerParserResult Tiled2dMapVectorLayerParserHelper::parseStyleJ
         }
     }
 
+    std::vector<std::shared_ptr<VectorMapSourceDescription>> sourceDescriptions;
+    for (auto const &[identifier, tileJson]: tileJsons) {
+        std::optional<::RectCoord> bounds;
+        if (tileJson.contains("bounds")) {
+            auto tmpBounds = std::vector<double>();
+            for (auto &el: tileJson["bounds"].items()) {
+                double d = el.value().get<double>();
+                tmpBounds.push_back(d);
+            }
+            if (tmpBounds.size() == 4) {
+                const auto topLeft = Coord(CoordinateSystemIdentifiers::EPSG4326(), tmpBounds[0], tmpBounds[1], 0);
+                const auto bottomRight = Coord(CoordinateSystemIdentifiers::EPSG4326(), tmpBounds[2], tmpBounds[3], 0);
+                bounds = RectCoord(topLeft, bottomRight);
+            }
+        }
+        auto zoomLevelScaleFactor = tileJson.contains("zoomLevelScaleFactor") ? std::optional<float>(tileJson["zoomLevelScaleFactor"].get<float>()) : std::nullopt;
+        auto adaptScaleToScreen = tileJson.contains("adaptScaleToScreen") ? std::optional<bool>(tileJson["adaptScaleToScreen"].get<bool>()) : std::nullopt;
+        auto numDrawPreviousLayers = tileJson.contains("numDrawPreviousLayers") ? std::optional<int>(tileJson["numDrawPreviousLayers"].get<int>()) : std::nullopt;
+        auto underzoom = tileJson.contains("underzoom") ? std::optional<bool>(tileJson["underzoom"].get<bool>()) : std::nullopt;
+        auto overzoom = tileJson.contains("overzoom") ? std::optional<bool>(tileJson["overzoom"].get<bool>()) : std::nullopt;
+        sourceDescriptions.push_back(
+                                     std::make_shared<VectorMapSourceDescription>(identifier,
+                                                                                  tileJson["tiles"].begin()->get<std::string>(),
+                                                                                  tileJson["minzoom"].get<int>(),
+                                                                                  tileJson["maxzoom"].get<int>(),
+                                                                                  bounds,
+                                                                                  zoomLevelScaleFactor,
+                                                                                  adaptScaleToScreen,
+                                                                                  numDrawPreviousLayers,
+                                                                                  underzoom,
+                                                                                  overzoom
+                                                                                  ));
+    }
+
+
     Tiled2dMapVectorStyleParser parser;
 
     std::optional<std::string> metadata;
@@ -324,15 +359,24 @@ Tiled2dMapVectorLayerParserResult Tiled2dMapVectorLayerParserHelper::parseStyleJ
                     parser.parseValue(val["paint"]["line-dotted"]),
                     parser.parseValue(val["paint"]["line-dotted-skew"])
             );
-            
+
+            int minZoom = 0;
+            int maxZoom = 24;
+            for (const auto &sourceDesc : sourceDescriptions) {
+                if (sourceDesc->identifier == val["source"]) {
+                    minZoom = sourceDesc->minZoom;
+                    maxZoom = sourceDesc->maxZoom;
+                }
+            }
+
             auto layerDesc = std::make_shared<LineVectorLayerDescription>(
                     val["id"],
                     val["source"],
                     val.value("source-layer", ""),
                     val.value("minzoom", 0),
                     val.value("maxzoom", 24),
-                    val.value("minzoom", 0),
-                    val.value("maxzoom", 24),
+                    minZoom,
+                    maxZoom,
                     filter,
                     style,
                     renderPassIndex,
@@ -390,13 +434,22 @@ Tiled2dMapVectorLayerParserResult Tiled2dMapVectorLayerParserHelper::parseStyleJ
 
             std::shared_ptr<Value> filter = parser.parseValue(val["filter"]);
 
+            int minZoom = 0;
+            int maxZoom = 24;
+            for (const auto &sourceDesc : sourceDescriptions) {
+                if (sourceDesc->identifier == val["source"]) {
+                    minZoom = sourceDesc->minZoom;
+                    maxZoom = sourceDesc->maxZoom;
+                }
+            }
+
             auto layerDesc = std::make_shared<SymbolVectorLayerDescription>(val["id"],
                                                                             val["source"],
                                                                             val.value("source-layer", ""),
                                                                             val.value("minzoom", 0),
                                                                             val.value("maxzoom", 24),
-                                                                            val.value("minzoom", 0),
-                                                                            val.value("maxzoom", 24),
+                                                                            minZoom,
+                                                                            maxZoom,
                                                                             filter,
                                                                             style,
                                                                             renderPassIndex,
@@ -414,13 +467,22 @@ Tiled2dMapVectorLayerParserResult Tiled2dMapVectorLayerParserHelper::parseStyleJ
                                      (!val["layout"]["fadeInPattern"].is_null()) && val["layout"].value("fadeInPattern", false),
                                      parser.parseValue(val["paint"]["stripe-width"]));
 
+            int minZoom = 0;
+            int maxZoom = 24;
+            for (const auto &sourceDesc : sourceDescriptions) {
+                if (sourceDesc->identifier == val["source"]) {
+                    minZoom = sourceDesc->minZoom;
+                    maxZoom = sourceDesc->maxZoom;
+                }
+            }
+
             auto layerDesc = std::make_shared<PolygonVectorLayerDescription>(val["id"],
                                                                              val["source"],
                                                                              val.value("source-layer", ""),
                                                                              val.value("minzoom", 0),
                                                                              val.value("maxzoom", 24),
-                                                                             val.value("minzoom", 0),
-                                                                             val.value("maxzoom", 24),
+                                                                             minZoom,
+                                                                             maxZoom,
                                                                              filter,
                                                                              style,
                                                                              renderPassIndex,
@@ -430,40 +492,6 @@ Tiled2dMapVectorLayerParserResult Tiled2dMapVectorLayerParserHelper::parseStyleJ
 
             layers.push_back(layerDesc);
         }
-    }
-
-    std::vector<std::shared_ptr<VectorMapSourceDescription>> sourceDescriptions;
-    for (auto const &[identifier, tileJson]: tileJsons) {
-        std::optional<::RectCoord> bounds;
-        if (tileJson.contains("bounds")) {
-            auto tmpBounds = std::vector<double>();
-            for (auto &el: tileJson["bounds"].items()) {
-                double d = el.value().get<double>();
-                tmpBounds.push_back(d);
-            }
-            if (tmpBounds.size() == 4) {
-                const auto topLeft = Coord(CoordinateSystemIdentifiers::EPSG4326(), tmpBounds[0], tmpBounds[1], 0);
-                const auto bottomRight = Coord(CoordinateSystemIdentifiers::EPSG4326(), tmpBounds[2], tmpBounds[3], 0);
-                bounds = RectCoord(topLeft, bottomRight);
-            }
-        }
-        auto zoomLevelScaleFactor = tileJson.contains("zoomLevelScaleFactor") ? std::optional<float>(tileJson["zoomLevelScaleFactor"].get<float>()) : std::nullopt;
-        auto adaptScaleToScreen = tileJson.contains("adaptScaleToScreen") ? std::optional<bool>(tileJson["adaptScaleToScreen"].get<bool>()) : std::nullopt;
-        auto numDrawPreviousLayers = tileJson.contains("numDrawPreviousLayers") ? std::optional<int>(tileJson["numDrawPreviousLayers"].get<int>()) : std::nullopt;
-        auto underzoom = tileJson.contains("underzoom") ? std::optional<bool>(tileJson["underzoom"].get<bool>()) : std::nullopt;
-        auto overzoom = tileJson.contains("overzoom") ? std::optional<bool>(tileJson["overzoom"].get<bool>()) : std::nullopt;
-        sourceDescriptions.push_back(
-                std::make_shared<VectorMapSourceDescription>(identifier,
-                                                             tileJson["tiles"].begin()->get<std::string>(),
-                                                             tileJson["minzoom"].get<int>(),
-                                                             tileJson["maxzoom"].get<int>(),
-                                                             bounds,
-                                                             zoomLevelScaleFactor,
-                                                             adaptScaleToScreen,
-                                                             numDrawPreviousLayers,
-                                                             underzoom,
-                                                             overzoom
-                ));
     }
 
 

--- a/shared/src/map/layers/tiled/vector/sourcemanagers/Tiled2dMapVectorSourceVectorTileDataManager.cpp
+++ b/shared/src/map/layers/tiled/vector/sourcemanagers/Tiled2dMapVectorSourceVectorTileDataManager.cpp
@@ -144,6 +144,11 @@ void Tiled2dMapVectorSourceVectorTileDataManager::onVectorTilesUpdated(const std
                         continue;
                     }
 
+                    if ((tile->tileInfo.tileInfo.zoomIdentifier < layer->minZoom ||
+                         tile->tileInfo.tileInfo.zoomIdentifier > layer->maxZoom) && tile->tileInfo.tileInfo.zoomIdentifier != layer->sourceMaxZoom) {
+                        continue;
+                    }
+
                     std::string identifier = layer->identifier;
                     Actor<Tiled2dMapVectorTile> actor = createTileActor(tile->tileInfo, layer);
 

--- a/shared/src/map/layers/tiled/vector/tiles/line/Tiled2dMapVectorLineTile.cpp
+++ b/shared/src/map/layers/tiled/vector/tiles/line/Tiled2dMapVectorLineTile.cpp
@@ -75,7 +75,7 @@ void Tiled2dMapVectorLineTile::update() {
 
     const double cameraZoom = camera->getZoom();
     double zoomIdentifier = layerConfig->getZoomIdentifier(cameraZoom);
-    
+
     if (!mapInterface->is3d()) {
         zoomIdentifier = std::max(zoomIdentifier, (double) tileInfo.tileInfo.zoomIdentifier);
     }
@@ -87,6 +87,17 @@ void Tiled2dMapVectorLineTile::update() {
     auto lineDescription = std::static_pointer_cast<LineVectorLayerDescription>(description);
     bool inZoomRange = lineDescription->maxZoom >= zoomIdentifier && lineDescription->minZoom <= zoomIdentifier;
 
+    if (inZoomRange != isVisible) {
+        isVisible = inZoomRange;
+        for (auto const &object : renderObjects) {
+            object->setHidden(!inZoomRange);
+        }
+    }
+
+    if (!inZoomRange) {
+        return;
+    }
+
     for (auto const &line: lines) {
         line->setScalingFactor(scalingFactor);
     }
@@ -94,14 +105,12 @@ void Tiled2dMapVectorLineTile::update() {
     if (lastAlpha == alpha &&
         lastZoom &&
         ((isStyleZoomDependant && *lastZoom == zoomIdentifier) || !isStyleZoomDependant) &&
-        (lastInZoomRange && *lastInZoomRange == inZoomRange) &&
         !isStyleStateDependant) {
         return;
     }
 
     lastZoom = zoomIdentifier;
     lastAlpha = alpha;
-    lastInZoomRange = inZoomRange;
 
     size_t numStyleGroups = featureGroups.size();
     for (int styleGroupId = 0; styleGroupId < numStyleGroups; styleGroupId++) {
@@ -112,7 +121,7 @@ void Tiled2dMapVectorLineTile::update() {
             auto &style = reusableLineStyles[styleGroupId][i];
 
             // color
-            auto color = inZoomRange ? lineDescription->style.getLineColor(context) : Color(0.0, 0.0, 0.0, 0.0);
+            auto color = lineDescription->style.getLineColor(context);
             if (color.r != style.colorR || color.g != style.colorG || color.b != style.colorB || color.a != style.colorA) {
                 style.colorR = color.r;
                 style.colorG = color.g;
@@ -122,14 +131,14 @@ void Tiled2dMapVectorLineTile::update() {
             }
 
             // opacity
-            float opacity = inZoomRange ? lineDescription->style.getLineOpacity(context) * alpha : 0.0;
+            float opacity = lineDescription->style.getLineOpacity(context) * alpha;
             if (opacity != style.opacity) {
                 style.opacity = opacity;
                 needsUpdate = true;
             }
 
-            // blue
-            float blur = inZoomRange ? lineDescription->style.getLineBlur(context) : 0.0;
+            // blur
+            float blur = lineDescription->style.getLineBlur(context);
             if (blur != style.blur) {
                 style.blur = blur;
                 needsUpdate = true;
@@ -144,14 +153,14 @@ void Tiled2dMapVectorLineTile::update() {
             }
 
             // width
-            float width = inZoomRange ? lineDescription->style.getLineWidth(context) : 0.0;
+            float width = lineDescription->style.getLineWidth(context);
             if (width != style.width) {
                 style.width = width;
                 needsUpdate = true;
             }
 
             // dashes
-            auto dashArray = inZoomRange ? lineDescription->style.getLineDashArray(context) : std::vector<float>{};
+            auto dashArray = lineDescription->style.getLineDashArray(context);
             auto dn = dashArray.size();
             auto dValue0 = dn > 0 ? dashArray[0] : 0.0;
             auto dValue1 = (dn > 1 ? dashArray[1] : 0.0) + dValue0;
@@ -184,7 +193,7 @@ void Tiled2dMapVectorLineTile::update() {
             }
 
             // offset
-            auto offset = inZoomRange ? lineDescription->style.getLineOffset(context, width) : 0.0;
+            auto offset = lineDescription->style.getLineOffset(context, width);
             if(offset != style.offset) {
                 style.offset = offset;
                 needsUpdate = true;
@@ -398,6 +407,14 @@ void Tiled2dMapVectorLineTile::addLines(const std::vector<std::vector<std::vecto
 
     lines = lineGroupObjects;
 
+    std::vector<std::shared_ptr<RenderObjectInterface>> newRenderObjects;
+    for (auto const &object : lines) {
+        for (const auto &config : object->getRenderConfig()) {
+            newRenderObjects.push_back(std::make_shared<RenderObject>(config->getGraphicsObject()));
+        }
+    }
+    renderObjects = newRenderObjects;
+
 #ifdef __APPLE__
     setupLines(newGraphicObjects);
 #else
@@ -425,15 +442,7 @@ void Tiled2dMapVectorLineTile::setupLines(const std::vector<std::shared_ptr<Grap
 
 
 std::vector<std::shared_ptr<RenderObjectInterface>> Tiled2dMapVectorLineTile::generateRenderObjects() {
-    std::vector<std::shared_ptr<RenderObjectInterface>> newRenderObjects;
-
-    for (auto const &object : lines) {
-        for (const auto &config : object->getRenderConfig()) {
-            newRenderObjects.push_back(std::make_shared<RenderObject>(config->getGraphicsObject()));
-        }
-    }
-
-    return newRenderObjects;
+    return renderObjects;
 }
 
 bool Tiled2dMapVectorLineTile::onClickConfirmed(const Vec2F &posScreen) {

--- a/shared/src/map/layers/tiled/vector/tiles/line/Tiled2dMapVectorLineTile.h
+++ b/shared/src/map/layers/tiled/vector/tiles/line/Tiled2dMapVectorLineTile.h
@@ -60,6 +60,7 @@ private:
     std::vector<std::shared_ptr<LineGroupShaderInterface>> shaders;
 
     std::vector<std::shared_ptr<LineGroup2dLayerObject>> lines;
+    std::vector<std::shared_ptr<RenderObjectInterface>> renderObjects;
 
     std::vector<std::vector<std::tuple<size_t, std::shared_ptr<FeatureContext>>>> featureGroups;
 
@@ -69,7 +70,7 @@ private:
     bool isStyleZoomDependant = true;
     bool isStyleStateDependant = true;
     std::optional<double> lastZoom = std::nullopt;
-    std::optional<bool> lastInZoomRange = std::nullopt;
+    bool isVisible = true;
 
     std::vector<std::vector<ShaderLineStyle>> reusableLineStyles;
     std::unordered_map<size_t, std::pair<int, int>> styleHashToGroupMap;

--- a/shared/src/map/layers/tiled/vector/tiles/polygon/Tiled2dMapVectorPolygonPatternTile.cpp
+++ b/shared/src/map/layers/tiled/vector/tiles/polygon/Tiled2dMapVectorPolygonPatternTile.cpp
@@ -87,11 +87,21 @@ void Tiled2dMapVectorPolygonPatternTile::update() {
 
     auto polygonDescription = std::static_pointer_cast<PolygonVectorLayerDescription>(description);
     bool inZoomRange = polygonDescription->maxZoom >= zoomIdentifier && polygonDescription->minZoom <= zoomIdentifier;
-    
+
+    if (inZoomRange != isVisible) {
+        isVisible = inZoomRange;
+        for (auto const &object : renderObjects) {
+            object->setHidden(!inZoomRange);
+        }
+    }
+
+    if (!inZoomRange) {
+        return;
+    }
+
     if (lastZoom &&
         ((isStyleZoomDependant && *lastZoom == zoomIdentifier) || !isStyleZoomDependant)
-        && (lastInZoomRange && *lastInZoomRange == inZoomRange) &&
-        !isStyleStateDependant) {
+        && !isStyleStateDependant) {
         for (const auto &[styleGroupId, polygons] : styleGroupPolygonsMap) {
             for (const auto &polygon: polygons) {
                 polygon->setScalingFactor(scalingFactor);
@@ -101,7 +111,6 @@ void Tiled2dMapVectorPolygonPatternTile::update() {
     }
 
     lastZoom = zoomIdentifier;
-    lastInZoomRange = inZoomRange;
 
     opacities.clear();
     size_t numStyleGroups = featureGroups.size();
@@ -109,13 +118,9 @@ void Tiled2dMapVectorPolygonPatternTile::update() {
         opacities.push_back(std::vector<float>(featureGroups.at(styleGroupId).size()));
         int index = 0;
         for (const auto &[hash, feature]: featureGroups.at(styleGroupId)) {
-            if (inZoomRange) {
-                const auto &ec = EvaluationContext(zoomIdentifier, dpFactor, feature, featureStateManager);
-                const auto &opacity = polygonDescription->style.getFillOpacity(ec);
-                opacities[styleGroupId][index] = alpha * opacity;
-            } else {
-                opacities[styleGroupId][index] = 0.0;
-            }
+            const auto &ec = EvaluationContext(zoomIdentifier, dpFactor, feature, featureStateManager);
+            const auto &opacity = polygonDescription->style.getFillOpacity(ec);
+            opacities[styleGroupId][index] = alpha * opacity;
             index++;
         }
         for (const auto &polygon: styleGroupPolygonsMap.at(styleGroupId)) {
@@ -325,6 +330,14 @@ void Tiled2dMapVectorPolygonPatternTile::addPolygons(const std::vector<std::vect
     styleGroupPolygonsMap = polygonGroupObjectsMap;
     polygonRenderOrder = polygonsRenderOrder;
 
+    std::vector<std::shared_ptr<RenderObjectInterface>> newRenderObjects;
+    for (const auto &polygon: polygonRenderOrder) {
+        for (const auto &config: polygon->getRenderConfig()) {
+            newRenderObjects.push_back(std::make_shared<RenderObject>(config->getGraphicsObject()));
+        }
+    }
+    renderObjects = newRenderObjects;
+
 #ifdef __APPLE__
     setupPolygons(newGraphicObjects);
 #else
@@ -351,14 +364,7 @@ void Tiled2dMapVectorPolygonPatternTile::setupPolygons(const std::vector<std::sh
 }
 
 std::vector<std::shared_ptr<RenderObjectInterface>> Tiled2dMapVectorPolygonPatternTile::generateRenderObjects() {
-    std::vector<std::shared_ptr<RenderObjectInterface>> newRenderObjects;
-    for (const auto &polygon: polygonRenderOrder) {
-        for (const auto &config: polygon->getRenderConfig()) {
-            newRenderObjects.push_back(std::make_shared<RenderObject>(config->getGraphicsObject()));
-        }
-    }
-
-    return newRenderObjects;
+    return renderObjects;
 }
 
 void Tiled2dMapVectorPolygonPatternTile::setSpriteData(const std::shared_ptr<SpriteData> &spriteData,

--- a/shared/src/map/layers/tiled/vector/tiles/polygon/Tiled2dMapVectorPolygonPatternTile.h
+++ b/shared/src/map/layers/tiled/vector/tiles/polygon/Tiled2dMapVectorPolygonPatternTile.h
@@ -71,12 +71,14 @@ private:
     std::unordered_map<int, std::vector<std::shared_ptr<PolygonPatternGroup2dLayerObject>>> styleGroupPolygonsMap;
     std::vector<std::shared_ptr<PolygonPatternGroup2dLayerObject>> polygonRenderOrder;
     std::vector<std::vector<std::tuple<size_t, std::shared_ptr<FeatureContext>>>> featureGroups;
+    std::vector<std::shared_ptr<RenderObjectInterface>> renderObjects;
+
     std::unordered_map<size_t, std::pair<int, int>> styleHashToGroupMap;
     UsedKeysCollection usedKeys;
     bool isStyleZoomDependant = true;
     bool isStyleStateDependant = true;
     std::optional<double> lastZoom = std::nullopt;
-    std::optional<bool> lastInZoomRange = std::nullopt;
+    bool isVisible = true;
 
     bool fadeInPattern = false;
 

--- a/shared/src/map/layers/tiled/vector/tiles/polygon/Tiled2dMapVectorPolygonTile.h
+++ b/shared/src/map/layers/tiled/vector/tiles/polygon/Tiled2dMapVectorPolygonTile.h
@@ -63,6 +63,7 @@ private:
 
     std::vector<std::shared_ptr<PolygonGroupShaderInterface>> shaders;
     std::vector<std::shared_ptr<PolygonGroup2dLayerObject>> polygons;
+    std::vector<std::shared_ptr<RenderObjectInterface>> renderObjects;
     std::vector<std::vector<std::tuple<size_t, std::shared_ptr<FeatureContext>>>> featureGroups;
     std::unordered_map<size_t, std::pair<int, int>> styleHashToGroupMap;
     UsedKeysCollection usedKeys;
@@ -71,7 +72,7 @@ private:
     bool isStriped = false;
 
     std::optional<double> lastZoom = std::nullopt;
-    std::optional<bool> lastInZoomRange = std::nullopt;
+    bool isVisible = true;
 
     std::vector<std::tuple<VectorTileGeometryHandler::TriangulatedPolygon, std::shared_ptr<FeatureContext>>> hitDetectionPolygons;
 

--- a/shared/src/map/layers/tiled/vector/tiles/raster/Tiled2dMapVectorRasterTile.h
+++ b/shared/src/map/layers/tiled/vector/tiles/raster/Tiled2dMapVectorRasterTile.h
@@ -52,7 +52,7 @@ private:
     bool isStyleZoomDependant = true;
     bool isStyleStateDependant = true;
     std::optional<double> lastZoom = std::nullopt;
-    std::optional<bool> lastInZoomRange = std::nullopt;
+    bool isVisible = true;
 
     std::optional<RasterShaderStyle> lastStyle;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added methods to manage the visibility state of render objects across various components, including `setHidden` and `isHidden`.
	- Enhanced visibility control logic for tiles based on zoom levels in multiple tile classes.

- **Bug Fixes**
	- Improved handling of visibility states to ensure proper rendering of objects based on zoom range.

- **Refactor**
	- Streamlined rendering logic and visibility checks in several classes, enhancing efficiency and clarity.

- **Chores**
	- Updated internal state management for visibility in various classes, replacing optional variables with explicit boolean flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->