### PR TITLE
Lock the mailbox of the vector layer actor after creating it

### DIFF
--- a/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayer.cpp
+++ b/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayer.cpp
@@ -293,6 +293,10 @@ void Tiled2dMapVectorLayer::initializeVectorLayer() {
     if (!mailbox) {
         selfMailbox = std::make_shared<Mailbox>(mapInterface->getScheduler());
     }
+
+    //lock the mailbox so we are a safe actor
+    std::lock_guard<std::recursive_mutex> mailboxLock(selfMailbox->receivingMutex);
+
     auto castedMe = std::static_pointer_cast<Tiled2dMapVectorLayer>(shared_from_this());
     auto selfActor = WeakActor<Tiled2dMapVectorLayer>(selfMailbox, castedMe);
     auto selfRasterActor = WeakActor<Tiled2dMapRasterSourceListener>(selfMailbox, castedMe);


### PR DESCRIPTION
this fixes a random crash when generating the renderpasses