### PR TITLE
improve zoom level limit parsing

### DIFF
--- a/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayerParserHelper.cpp
+++ b/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayerParserHelper.cpp
@@ -104,9 +104,9 @@ Tiled2dMapVectorLayerParserResult Tiled2dMapVectorLayerParserHelper::parseStyleJ
             }
             if (!levels.has_value()) {
                 minZoom = val.value("minzoom", 0);
-                maxZoom = val.value("maxzoom", 22);
+                maxZoom = val.value("maxzoom", 24);
             }
-
+            
             std::optional<::RectCoord> bounds;
             std::optional<std::string> coordinateReferenceSystem;
 
@@ -166,15 +166,15 @@ Tiled2dMapVectorLayerParserResult Tiled2dMapVectorLayerParserHelper::parseStyleJ
                 }
 
                 minZoom = json.value("minzoom", 0);
-                maxZoom = json.value("maxzoom", 22);
+                maxZoom = json.value("maxzoom", 24);
             }
 
 
             RasterVectorStyle style = RasterVectorStyle(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
             rasterLayerMap[key] = std::make_shared<RasterVectorLayerDescription>(layerName,
                                                                                  key,
-                                                                                 minZoom,
-                                                                                 maxZoom,
+                                                                                 0,
+                                                                                 24,
                                                                                  minZoom,
                                                                                  maxZoom,
                                                                                  url,
@@ -264,7 +264,7 @@ Tiled2dMapVectorLayerParserResult Tiled2dMapVectorLayerParserHelper::parseStyleJ
         }
         if (!levels.has_value()) {
             minZoom = tileJson.value("minzoom", 0);
-            maxZoom = tileJson.value("maxzoom", 22);
+            maxZoom = tileJson.value("maxzoom", 24);
         }
 
         sourceDescriptions.push_back(
@@ -365,8 +365,8 @@ Tiled2dMapVectorLayerParserResult Tiled2dMapVectorLayerParserHelper::parseStyleJ
                                                                            val["source"],
                                                                            val.value("minzoom", layer->minZoom),
                                                                            val.value("maxzoom", layer->maxZoom),
-                                                                           layer->minZoom,
-                                                                           layer->maxZoom,
+                                                                           layer->sourceMinZoom,
+                                                                           layer->sourceMaxZoom,
                                                                            layer->url,
                                                                            filter,
                                                                            style,

--- a/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayerParserHelper.cpp
+++ b/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayerParserHelper.cpp
@@ -104,7 +104,7 @@ Tiled2dMapVectorLayerParserResult Tiled2dMapVectorLayerParserHelper::parseStyleJ
             }
             if (!levels.has_value()) {
                 minZoom = val.value("minzoom", 0);
-                maxZoom = val.value("maxzoom", 24);
+                maxZoom = val.value("maxzoom", 22);
             }
             
             std::optional<::RectCoord> bounds;
@@ -166,7 +166,7 @@ Tiled2dMapVectorLayerParserResult Tiled2dMapVectorLayerParserHelper::parseStyleJ
                 }
 
                 minZoom = json.value("minzoom", 0);
-                maxZoom = json.value("maxzoom", 24);
+                maxZoom = json.value("maxzoom", 22);
             }
 
 
@@ -264,7 +264,7 @@ Tiled2dMapVectorLayerParserResult Tiled2dMapVectorLayerParserHelper::parseStyleJ
         }
         if (!levels.has_value()) {
             minZoom = tileJson.value("minzoom", 0);
-            maxZoom = tileJson.value("maxzoom", 24);
+            maxZoom = tileJson.value("maxzoom", 22);
         }
 
         sourceDescriptions.push_back(
@@ -399,7 +399,7 @@ Tiled2dMapVectorLayerParserResult Tiled2dMapVectorLayerParserHelper::parseStyleJ
             );
 
             int minZoom = 0;
-            int maxZoom = 24;
+            int maxZoom = 22;
             for (const auto &sourceDesc : sourceDescriptions) {
                 if (sourceDesc->identifier == val["source"]) {
                     minZoom = sourceDesc->minZoom;
@@ -479,7 +479,7 @@ Tiled2dMapVectorLayerParserResult Tiled2dMapVectorLayerParserHelper::parseStyleJ
             std::shared_ptr<Value> filter = parser.parseValue(val["filter"]);
 
             int minZoom = 0;
-            int maxZoom = 24;
+            int maxZoom = 22;
             for (const auto &sourceDesc : sourceDescriptions) {
                 if (sourceDesc->identifier == val["source"]) {
                     minZoom = sourceDesc->minZoom;
@@ -512,7 +512,7 @@ Tiled2dMapVectorLayerParserResult Tiled2dMapVectorLayerParserHelper::parseStyleJ
                                      parser.parseValue(val["paint"]["stripe-width"]));
 
             int minZoom = 0;
-            int maxZoom = 24;
+            int maxZoom = 22;
             for (const auto &sourceDesc : sourceDescriptions) {
                 if (sourceDesc->identifier == val["source"]) {
                     minZoom = sourceDesc->minZoom;


### PR DESCRIPTION
This pull request includes changes to the `Tiled2dMapVectorLayerParserHelper` class to update the maximum zoom level and adjust the zoom level parameters in various parts of the code.

Changes to zoom levels:

* [`shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayerParserHelper.cpp`](diffhunk://#diff-b5b2f7b1f4f4acf3c840bab111d316349bffef79fe1fdf0a395ab10b670ff348L107-R107): Updated the maximum zoom level from 22 to 24 in multiple instances within the `parseStyleJ` method. [[1]](diffhunk://#diff-b5b2f7b1f4f4acf3c840bab111d316349bffef79fe1fdf0a395ab10b670ff348L107-R107) [[2]](diffhunk://#diff-b5b2f7b1f4f4acf3c840bab111d316349bffef79fe1fdf0a395ab10b670ff348L169-R177) [[3]](diffhunk://#diff-b5b2f7b1f4f4acf3c840bab111d316349bffef79fe1fdf0a395ab10b670ff348L267-R267)

Adjustments to zoom level parameters:

* [`shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayerParserHelper.cpp`](diffhunk://#diff-b5b2f7b1f4f4acf3c840bab111d316349bffef79fe1fdf0a395ab10b670ff348L169-R177): Changed the parameters for `rasterLayerMap` and `sourceDescriptions` to use `sourceMinZoom` and `sourceMaxZoom` instead of `minZoom` and `maxZoom`. [[1]](diffhunk://#diff-b5b2f7b1f4f4acf3c840bab111d316349bffef79fe1fdf0a395ab10b670ff348L169-R177) [[2]](diffhunk://#diff-b5b2f7b1f4f4acf3c840bab111d316349bffef79fe1fdf0a395ab10b670ff348L368-R369)