### PR TITLE
Empty state in Tiled2dMapVectorStateManager

### DIFF
--- a/shared/public/Tiled2dMapVectorStateManager.h
+++ b/shared/public/Tiled2dMapVectorStateManager.h
@@ -53,7 +53,7 @@ public:
             featureStates.emplace_back(intIdentifier, std::move(convertedProperties));
             hasNoValues = false;
         } else {
-            hasNoValues = !featureStates.empty() && !globalState.empty();
+            hasNoValues = featureStates.empty() && globalState.empty();
         }
 
         currentState++;
@@ -87,7 +87,7 @@ public:
             globalState.emplace(property.first, convertToValueVariant(property.second));
         }
 
-        hasNoValues = !properties.empty() && !featureStates.empty();
+        hasNoValues = properties.empty() && featureStates.empty();
         currentState++;
         globalStateId++;
     }


### PR DESCRIPTION
Wenn man feature state gesetzt hat und dann noch global state setzt werden alle states ignoriert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated state management logic to more accurately determine when no values are present in the map vector state.
	- Refined conditions for tracking empty feature states and global states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->