### PR TITLE
MAP-29: Store less Coords in the Vector Map

### DIFF
--- a/shared/public/LineGroup2dLayerObject.h
+++ b/shared/public/LineGroup2dLayerObject.h
@@ -31,6 +31,7 @@ class LineGroup2dLayerObject : public LayerObjectInterface {
 
     virtual std::vector<std::shared_ptr<RenderConfigInterface>> getRenderConfig() override;
 
+    void setLines(const std::vector<std::tuple<std::vector<Vec2D>, int>> &lines, const int32_t systemIdentifier, const Vec3D & origin);
     void setLines(const std::vector<std::tuple<std::vector<Coord>, int>> &lines, const Vec3D & origin);
 
     void setStyles(const std::vector<LineStyle> &styles);

--- a/shared/public/Vec2DHelper.h
+++ b/shared/public/Vec2DHelper.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "Vec2D.h"
+#include "Vec3D.h"
 #include "Quad2dD.h"
 #include <algorithm>
 #include <vector>
@@ -61,6 +62,11 @@ class Vec2DHelper {
 
     static inline double crossProduct(const Vec2D& A, const Vec2D& B) {
         return (A.x * B.y) - (A.y * B.x);
+    }
+
+    static inline Vec2D interpolate(const Vec2D& start, const Vec2D& end, double t) {
+        return Vec2D(start.x + (end.x - start.x) * t,
+                     start.y + (end.y - start.y) * t);
     }
 
     static inline ::Vec2D rotate(const ::Vec2D &p, const ::Vec2D &origin, double angleDegree) {
@@ -159,5 +165,17 @@ class Vec2DHelper {
 
     static inline ::Vec2D normalize(const ::Vec2D &vector) {
         return vector / std::sqrt(Vec2DHelper::squaredLength(vector));
+    }
+
+    static inline ::Vec2D toVec(const ::Coord &coordinate) {
+        return Vec2D(coordinate.x, coordinate.y);
+    }
+
+    static inline ::Vec3D toVec3D(const ::Vec2D &vec) {
+        return Vec3D(vec.x, vec.y, 0.0);
+    }
+
+    static inline ::Coord toCoord(const ::Vec2D &vec, const int32_t systemIdentifier) {
+        return Coord(systemIdentifier, vec.x, vec.y, 0.0);
     }
 };

--- a/shared/public/Vec3DHelper.h
+++ b/shared/public/Vec3DHelper.h
@@ -57,4 +57,12 @@ class Vec3DHelper {
     static inline ::Vec3D normalize(const ::Vec3D &vector) {
         return vector / std::sqrt(Vec3DHelper::squaredLength(vector));
     }
+
+    static inline ::Vec3D toVec(const ::Coord &coordinate) {
+        return Vec3D(coordinate.x, coordinate.y, coordinate.z);
+    }
+
+    static inline ::Coord toCoord(const ::Vec3D &vec, const int32_t systemIdentifier) {
+        return Coord(systemIdentifier, vec.x, vec.y, vec.z);
+    }
 };

--- a/shared/public/VectorTileGeometryHandler.h
+++ b/shared/public/VectorTileGeometryHandler.h
@@ -66,9 +66,10 @@ public:
             case vtzero::GeomType::POINT:
             case vtzero::GeomType::LINESTRING: {
                 for (auto const &points: geometry->coordinates) {
-                    std::vector<Coord> temp;
+                    std::vector<Vec2D> temp;
                     for (auto const &point: points) {
-                        temp.push_back(point);
+                        //TODO: change geojson to vec2d as well
+                        temp.push_back(Vec2D(point.x, point.y));
                     }
                     coordinates.push_back(temp);
                 }
@@ -85,7 +86,7 @@ public:
     VectorTileGeometryHandler(const VectorTileGeometryHandler& other) = delete;
 
     void points_begin(const uint32_t count) {
-        currentFeature = std::vector<::Coord>();
+        currentFeature = std::vector<::Vec2D>();
         currentFeature.reserve(count);
     }
 
@@ -99,7 +100,7 @@ public:
     }
 
     void linestring_begin(const uint32_t count) {
-        currentFeature = std::vector<::Coord>();
+        currentFeature = std::vector<::Vec2D>();
         currentFeature.reserve(count);
     }
 
@@ -195,7 +196,7 @@ public:
             coordinates.emplace_back();
             coordinates.back().reserve(geometry->coordinates[i].size());
             for (auto const &point: geometry->coordinates[i]){
-                coordinates.back().push_back(point);
+                coordinates.back().push_back(Vec2D(point.x, point.y));
             }
             polygon.emplace_back(geometry->coordinates[i]);
 
@@ -203,7 +204,7 @@ public:
                 coordinates.emplace_back();
                 coordinates.back().reserve(hole.size());
                 for (auto const &point: hole){
-                    coordinates.back().push_back(point);
+                    coordinates.back().push_back(Vec2D(point.x, point.y));
                 }
 
                 polygon.emplace_back(hole);
@@ -225,7 +226,7 @@ public:
         }
     }
 
-    std::vector<std::vector<::Coord>> &getLineCoordinates() {
+    std::vector<std::vector<::Vec2D>> &getLineCoordinates() {
         return coordinates;
     }
 
@@ -238,7 +239,7 @@ public:
         return polygons;
     }
 
-    const std::vector<std::vector<::Coord>> &getPointCoordinates() const {
+    const std::vector<std::vector<::Vec2D>> &getPointCoordinates() const {
         return coordinates;
     }
 
@@ -277,7 +278,7 @@ public:
     }
 
 private:
-    inline Coord coordinateFromPoint(const vtzero::point &point, bool renderSystem) {
+    inline Vec2D coordinateFromPoint(const vtzero::point &point, bool renderSystem) {
         auto tx = point.x / extent;
         auto ty = point.y / extent;
 
@@ -300,15 +301,15 @@ private:
         const auto y = tileCoords.topLeft.y * (1.0 - ty) + tileCoords.bottomRight.y * ty;
 
         if (renderSystem) {
-            return conversionHelper->convertToRenderSystem(Coord(tileCoords.topLeft.systemIdentifier, x, y, 0.0));
+            const auto coord = conversionHelper->convertToRenderSystem(Coord(tileCoords.topLeft.systemIdentifier, x, y, 0.0));
+            return Vec2D(coord.x, coord.y);
         } else {
-            return Coord(tileCoords.topLeft.systemIdentifier, x, y, 0.0);
+            return Vec2D(x, y);
         }
     }
 
     inline Vec2D vecFromPoint(const vtzero::point &point) {
-        const auto coord = coordinateFromPoint(point, true);
-        return Vec2D(coord.x, coord.y);
+        return coordinateFromPoint(point, true);
     }
 
 
@@ -352,8 +353,8 @@ private:
          }
     }
 
-    std::vector<::Coord> currentFeature;
-    std::vector<std::vector<::Coord>> coordinates;
+    std::vector<::Vec2D> currentFeature;
+    std::vector<std::vector<::Vec2D>> coordinates;
 
     std::vector<vtzero::point> polygonCurrentRing;
     std::vector<std::vector<vtzero::point>> polygonPoints;

--- a/shared/src/map/layers/objects/LineGroup2dLayerObject.cpp
+++ b/shared/src/map/layers/objects/LineGroup2dLayerObject.cpp
@@ -29,6 +29,90 @@ void LineGroup2dLayerObject::update() {}
 
 std::vector<std::shared_ptr<RenderConfigInterface>> LineGroup2dLayerObject::getRenderConfig() { return {renderConfig}; }
 
+void LineGroup2dLayerObject::setLines(const std::vector<std::tuple<std::vector<Vec2D>, int>> &lines, const int32_t systemIdentifier, const Vec3D & origin) {
+    std::vector<uint32_t> lineIndices;
+    std::vector<float> lineAttributes;
+
+    int numLines = (int) lines.size();
+
+    int lineIndexOffset = 0;
+    for (int lineIndex = 0; lineIndex < numLines; lineIndex++) {
+        int lineStyleIndex = std::get<1>(lines[lineIndex]);
+
+        std::vector<Vec3D> renderCoords;
+        for (auto const &mapCoord : std::get<0>(lines[lineIndex])) {
+            Coord renderCoord = conversionHelper->convertToRenderSystem(Coord(systemIdentifier, mapCoord.x, mapCoord.y, 0.0));
+
+            double x = is3d ? 1.0 * sin(renderCoord.y) * cos(renderCoord.x) - origin.x : renderCoord.x - origin.x;
+            double y = is3d ?  1.0 * cos(renderCoord.y) - origin.y : renderCoord.y - origin.y;
+            double z = is3d ? -1.0 * sin(renderCoord.y) * sin(renderCoord.x) - origin.z : 0.0;
+
+            renderCoords.push_back(Vec3D(x, y, z));
+        }
+
+        int pointCount = (int)renderCoords.size();
+
+        float prefixTotalLineLength = 0.0;
+
+        int iSecondToLast = pointCount - 2;
+        for (int i = 0; i <= iSecondToLast; i++) {
+            const Vec3D &p = renderCoords[i];
+            const Vec3D &pNext = renderCoords[i + 1];
+
+            float lengthNormalX = pNext.x - p.x;
+            float lengthNormalY = pNext.y - p.y;
+            float lineLength = std::sqrt(lengthNormalX * lengthNormalX + lengthNormalY * lengthNormalY);
+
+            // SegmentType (0 inner, 1 start, 2 end, 3 single segment) | lineStyleIndex
+            // (each one Byte, i.e. up to 256 styles if supported by shader!)
+            float lineStyleInfo = lineStyleIndex + (i == 0 && i == iSecondToLast ? (3 << 8)
+                    : (i == 0 ? (float) (1 << 8)
+                    : (i == iSecondToLast ? (float) (2 << 8)
+                    : 0.0)));
+
+            for (uint8_t vertexIndex = 4; vertexIndex > 0; --vertexIndex) {
+                // Vertex
+                // Position pointA and pointB
+                lineAttributes.push_back(p.x);
+                lineAttributes.push_back(p.y);
+                if (is3d) {
+                    lineAttributes.push_back(p.z);
+                }
+                lineAttributes.push_back(pNext.x);
+                lineAttributes.push_back(pNext.y);
+                if (is3d) {
+                    lineAttributes.push_back(pNext.z);
+                }
+
+                // Vertex Index
+                lineAttributes.push_back((float) (vertexIndex - 1));
+
+                // Segment Start Length Position (length prefix sum)
+                lineAttributes.push_back(prefixTotalLineLength);
+
+                // Style Info
+                lineAttributes.push_back(lineStyleInfo);
+            }
+
+            // Vertex indices
+            lineIndices.push_back(lineIndexOffset + 4 * i);
+            lineIndices.push_back(lineIndexOffset + 4 * i + 1);
+            lineIndices.push_back(lineIndexOffset + 4 * i + 2);
+
+            lineIndices.push_back(lineIndexOffset + 4 * i);
+            lineIndices.push_back(lineIndexOffset + 4 * i + 2);
+            lineIndices.push_back(lineIndexOffset + 4 * i + 3);
+
+            prefixTotalLineLength += lineLength;
+        }
+        lineIndexOffset += ((pointCount - 1) * 4);
+    }
+
+    auto attributes = SharedBytes((int64_t) lineAttributes.data(), (int32_t) lineAttributes.size(), (int32_t) sizeof(float));
+    auto indices = SharedBytes((int64_t) lineIndices.data(), (int32_t) lineIndices.size(), (int32_t) sizeof(uint32_t));
+    line->setLines(attributes, indices, origin, is3d);
+}
+
 void LineGroup2dLayerObject::setLines(const std::vector<std::tuple<std::vector<Coord>, int>> &lines, const Vec3D & origin) {
 
     std::vector<uint32_t> lineIndices;

--- a/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayer.cpp
+++ b/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayer.cpp
@@ -1429,10 +1429,11 @@ std::vector<VectorLayerFeatureCoordInfo> Tiled2dMapVectorLayer::getVisiblePointF
                 for (auto const &[featureContext, geometry]: *it->second) {
                     for (auto const &points: geometry->getPointCoordinates()) {
                         for (auto const &point: points) {
-                            bool isVisible = camera->coordIsVisibleOnScreen(point, paddingPc);
+                            const auto coord = Vec2DHelper::toCoord(point, CoordinateSystemIdentifiers::EPSG3857());
+                            bool isVisible = camera->coordIsVisibleOnScreen(coord, paddingPc);
 
                             if (isVisible) {
-                                features.push_back(VectorLayerFeatureCoordInfo(featureContext->getFeatureInfo(), point));
+                                features.push_back(VectorLayerFeatureCoordInfo(featureContext->getFeatureInfo(), coord));
                             }
                         }
                     }

--- a/shared/src/map/layers/tiled/vector/symbol/SymbolAnimationCoordinator.h
+++ b/shared/src/map/layers/tiled/vector/symbol/SymbolAnimationCoordinator.h
@@ -17,7 +17,7 @@
 
 class SymbolAnimationCoordinator {
 public:
-    SymbolAnimationCoordinator(const Coord &coordinate,
+    SymbolAnimationCoordinator(const Vec2D &coordinate,
                                const int zoomIdentifier,
                                const double xTolerance,
                                const double yTolerance,
@@ -31,7 +31,7 @@ public:
     animationDuration(animationDuration),
     animationDelay(animationDelay){}
 
-    bool isMatching(const Coord &coordinate, const int zoomIdentifier) const {
+    bool isMatching(const Vec2D &coordinate, const int zoomIdentifier) const {
         const double toleranceFactor = 1 << std::max(0, this->zoomIdentifier - zoomIdentifier); // more efficient than: std::max(1.0, std::pow(2, this->zoomIdentifier - zoomIdentifier))
         const double xDistance = std::abs(this->coordinate.x - coordinate.x);
         const double yDistance = std::abs(this->coordinate.y - coordinate.y);
@@ -117,7 +117,7 @@ public:
         animationsEnabled = enabled;
     }
 
-    const Coord coordinate;
+    const Vec2D coordinate;
     const int zoomIdentifier;
 private:
     const double xTolerance;

--- a/shared/src/map/layers/tiled/vector/symbol/SymbolAnimationCoordinatorMap.h
+++ b/shared/src/map/layers/tiled/vector/symbol/SymbolAnimationCoordinatorMap.h
@@ -22,7 +22,7 @@ class SymbolAnimationCoordinatorMap {
 public:
 
     std::shared_ptr<SymbolAnimationCoordinator> getOrAddAnimationController(size_t crossTileIdentifier,
-                                                                            const Coord &coord,
+                                                                            const Vec2D &coord,
                                                                             int zoomIdentifier,
                                                                             double xTolerance,
                                                                             double yTolerance,

--- a/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSymbolGroup.cpp
+++ b/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSymbolGroup.cpp
@@ -82,7 +82,7 @@ void Tiled2dMapVectorSymbolGroup::initialize(std::weak_ptr<std::vector<Tiled2dMa
     const double tilePixelFactor =
             (0.0254 / camera->getScreenDensityPpi()) * layerConfig->getZoomFactorAtIdentifier(tileInfo.tileInfo.zoomIdentifier - 1);
 
-    std::unordered_map<std::string, std::vector<Coord>> textPositionMap;
+    std::unordered_map<std::string, std::vector<Vec2D>> textPositionMap;
 
     std::vector<VectorLayerFeatureInfo> featureInfosWithCustomAssets;
 
@@ -147,7 +147,7 @@ void Tiled2dMapVectorSymbolGroup::initialize(std::weak_ptr<std::vector<Tiled2dMa
 
             bool isLineCenter = placement == TextSymbolPlacement::LINE_CENTER;
 
-            std::vector<Coord> line = {};
+            std::vector<Vec2D> line = {};
             for (const auto &points: pointCoordinates) {
                 line.insert(line.end(), points.begin(), points.end());
             }
@@ -948,7 +948,7 @@ void Tiled2dMapVectorSymbolGroup::update(const double zoomIdentifier, const doub
 }
 
 std::optional<Tiled2dMapVectorSymbolSubLayerPositioningWrapper>
-Tiled2dMapVectorSymbolGroup::getPositioning(std::vector<::Coord>::const_iterator &iterator, const std::vector<::Coord> &collection,
+Tiled2dMapVectorSymbolGroup::getPositioning(std::vector<::Vec2D>::const_iterator &iterator, const std::vector<::Vec2D> &collection,
                                             const double interpolationValue) {
 
     double distance = 10;
@@ -985,7 +985,7 @@ Tiled2dMapVectorSymbolGroup::getPositioning(std::vector<::Coord>::const_iterator
     double angle = -atan2(prev->y - next->y, -(prev->x - next->x)) * (180.0 / M_PI);
     auto midpoint = Vec2D(onePrev->x * (1.0 - interpolationValue) + iterator->x * interpolationValue,
                           onePrev->y * (1.0 - interpolationValue) + iterator->y * interpolationValue);
-    return Tiled2dMapVectorSymbolSubLayerPositioningWrapper(angle, Coord(next->systemIdentifier, midpoint.x, midpoint.y, next->z));
+    return Tiled2dMapVectorSymbolSubLayerPositioningWrapper(angle, midpoint);
 }
 
 std::shared_ptr<Tiled2dMapVectorSymbolObject>
@@ -996,8 +996,8 @@ Tiled2dMapVectorSymbolGroup::createSymbolObject(const Tiled2dMapVersionedTileInf
                                                 const std::shared_ptr<FeatureContext> &featureContext,
                                                 const std::vector<FormattedStringEntry> &text,
                                                 const std::string &fullText,
-                                                const ::Coord &coordinate,
-                                                const std::optional<std::vector<Coord>> &lineCoordinates,
+                                                const ::Vec2D &coordinate,
+                                                const std::optional<std::vector<Vec2D>> &lineCoordinates,
                                                 const std::vector<std::string> &fontList,
                                                 const Anchor &textAnchor,
                                                 const std::optional<double> &angle,

--- a/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSymbolGroup.h
+++ b/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSymbolGroup.h
@@ -76,7 +76,7 @@ public:
 private:
 
     inline std::optional<Tiled2dMapVectorSymbolSubLayerPositioningWrapper>
-    getPositioning(std::vector<::Coord>::const_iterator &iterator, const std::vector<::Coord> &collection, const double interpolationValue);
+    getPositioning(std::vector<::Vec2D>::const_iterator &iterator, const std::vector<::Vec2D> &collection, const double interpolationValue);
 
     inline std::shared_ptr<Tiled2dMapVectorSymbolObject> createSymbolObject(const Tiled2dMapVersionedTileInfo &tileInfo,
                                                                             const std::string &layerIdentifier,
@@ -85,8 +85,8 @@ private:
                                                                             const std::shared_ptr<FeatureContext> &featureContext,
                                                                             const std::vector<FormattedStringEntry> &text,
                                                                             const std::string &fullText,
-                                                                            const ::Coord &coordinate,
-                                                                            const std::optional<std::vector<Coord>> &lineCoordinates,
+                                                                            const ::Vec2D &coordinate,
+                                                                            const std::optional<std::vector<Vec2D>> &lineCoordinates,
                                                                             const std::vector<std::string> &fontList,
                                                                             const Anchor &textAnchor,
                                                                             const std::optional<double> &angle,

--- a/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSymbolLabelObject.h
+++ b/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSymbolLabelObject.h
@@ -48,8 +48,8 @@ public:
                                       const std::shared_ptr<SymbolVectorLayerDescription> &description,
                                       const std::vector<FormattedStringEntry> &text,
                                       const std::string &fullText,
-                                      const ::Coord &coordinate,
-                                      const std::optional<std::vector<Coord>> &lineCoordinates,
+                                      const ::Vec2D &coordinate,
+                                      const std::optional<std::vector<Vec2D>> &lineCoordinates,
                                       const Anchor &textAnchor,
                                       const TextJustify &textJustify,
                                       const std::shared_ptr<FontLoaderResult> fontResult,
@@ -106,8 +106,8 @@ private:
     DistanceIndex findReferencePointIndices();
 
     inline Vec2D pointAtIndex(const DistanceIndex &index, bool useRender) {
-        const auto &s = useRender ? renderLineCoordinates[index.index] : (*lineCoordinates)[index.index];
-        const auto &e = useRender ?  renderLineCoordinates[index.index + 1 < renderLineCoordinatesCount ? (index.index + 1) : index.index] : (*lineCoordinates)[index.index + 1 < renderLineCoordinatesCount ? (index.index + 1) : index.index];
+        const auto &s = useRender ? renderLineCoordinates[index.index] : Vec2DHelper::toVec3D((*lineCoordinates)[index.index]);
+        const auto &e = useRender ?  renderLineCoordinates[index.index + 1 < renderLineCoordinatesCount ? (index.index + 1) : index.index] : Vec2DHelper::toVec3D((*lineCoordinates)[index.index + 1 < renderLineCoordinatesCount ? (index.index + 1) : index.index]);
         return Vec2D(s.x + (e.x - s.x) * index.percentage,
                      s.y + (e.y - s.y) * index.percentage);
     }
@@ -194,9 +194,9 @@ private:
 
     const std::shared_ptr<FontLoaderResult> fontResult;
 
-    Coord referencePoint = Coord(0,0,0,0);
-    Vec3D cartesianReferencePoint = Vec3D(0,0,0);
-    Coord referencePointScreen = Coord(0,0,0,0);
+    Vec3D referencePoint = Vec3D(0.0, 0.0, 0.0);
+    Vec3D cartesianReferencePoint = Vec3D(0.0, 0.0, 0.0);
+    Vec3D referencePointScreen = Vec3D(0.0, 0.0, 0);
     float referenceSize;
 
 
@@ -217,10 +217,10 @@ private:
     const std::string fullText;
 
     size_t renderLineCoordinatesCount;
-    std::vector<Coord> renderLineCoordinates;
-    std::vector<Coord> screenLineCoordinates;
+    std::vector<Vec3D> renderLineCoordinates;
+    std::vector<Vec3D> screenLineCoordinates;
     std::vector<Vec3D> cartesianRenderLineCoordinates;
-    std::optional<std::vector<Coord>> lineCoordinates;
+    std::optional<std::vector<Vec2D>> lineCoordinates;
 
     double textSize = 0;
     double textRotate = 0;

--- a/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSymbolObject.h
+++ b/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSymbolObject.h
@@ -38,8 +38,8 @@ public:
                                  const std::shared_ptr<FeatureContext> featureContext,
                                  const std::vector<FormattedStringEntry> &text,
                                  const std::string &fullText,
-                                 const ::Coord &coordinate,
-                                 const std::optional<std::vector<Coord>> &lineCoordinates,
+                                 const ::Vec2D &coordinate,
+                                 const std::optional<std::vector<Vec2D>> &lineCoordinates,
                                  const std::vector<std::string> &fontList,
                                  const Anchor &textAnchor,
                                  const std::optional<double> &angle,
@@ -124,7 +124,7 @@ private:
 
     void writePosition(const double x, const double y, const size_t offset, VectorModificationWrapper<float> &buffer);
 
-    ::Coord getRenderCoordinates(Anchor iconAnchor, double rotation, double iconWidth, double iconHeight);
+    ::Vec2D getRenderCoordinates(Anchor iconAnchor, double rotation, double iconWidth, double iconHeight);
 
     std::shared_ptr<Tiled2dMapVectorLayerConfig> layerConfig;
 
@@ -138,8 +138,8 @@ private:
 
     std::shared_ptr<SymbolVectorLayerDescription> description;
 
-    const ::Coord coordinate;
-    ::Coord renderCoordinate = Coord(0, 0, 0, 0);
+    const ::Vec2D coordinate;
+    ::Vec2D renderCoordinate = Vec2D(0, 0);
     Vec2D initialRenderCoordinateVec = Vec2D(0, 0);
 
     SymbolObjectInstanceCounts instanceCounts = {0,0,0};

--- a/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSymbolSubLayerPositioningWrapper.h
+++ b/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSymbolSubLayerPositioningWrapper.h
@@ -14,7 +14,7 @@
 
 struct Tiled2dMapVectorSymbolSubLayerPositioningWrapper {
     double angle;
-    ::Coord centerPosition;
+    ::Vec2D centerPosition;
 
-    Tiled2dMapVectorSymbolSubLayerPositioningWrapper(double angle, ::Coord centerPosition): angle(angle), centerPosition(centerPosition) {}
+    Tiled2dMapVectorSymbolSubLayerPositioningWrapper(double angle, ::Vec2D centerPosition): angle(angle), centerPosition(centerPosition) {}
 };

--- a/shared/src/map/layers/tiled/vector/tiles/line/Tiled2dMapVectorLineTile.h
+++ b/shared/src/map/layers/tiled/vector/tiles/line/Tiled2dMapVectorLineTile.h
@@ -46,7 +46,7 @@ public:
     bool performClick(const Coord &coord) override;
 
 private:
-    void addLines(const std::vector<std::vector<std::vector<std::tuple<std::vector<Coord>, int>>>> &styleIdLinesVector);
+    void addLines(const std::vector<std::vector<std::vector<std::tuple<std::vector<Vec2D>, int>>>> &styleIdLinesVector);
 
     void setupLines(const std::vector<std::shared_ptr<GraphicsObjectInterface>> &newLineGraphicsObjects);
 
@@ -65,7 +65,7 @@ private:
 
     std::vector<std::vector<std::tuple<size_t, std::shared_ptr<FeatureContext>>>> featureGroups;
 
-    std::vector<std::tuple<std::vector<std::vector<::Coord>>, std::shared_ptr<FeatureContext>>> hitDetection;
+    std::vector<std::tuple<std::vector<std::vector<::Vec2D>>, std::shared_ptr<FeatureContext>>> hitDetection;
 
     UsedKeysCollection usedKeys;
     bool isStyleZoomDependant = true;

--- a/shared/src/utils/ReverseGeocoder.cpp
+++ b/shared/src/utils/ReverseGeocoder.cpp
@@ -18,6 +18,7 @@
 #include "vtzero/vector_tile.hpp"
 #include "CoordinateSystemIdentifiers.h"
 #include "VectorLayerFeatureCoordInfo.h"
+#include "CoordinateSystemIdentifiers.h"
 #include "Logger.h"
 
 ReverseGeocoder::ReverseGeocoder(const /*not-null*/ std::shared_ptr<::LoaderInterface> & loader, const std::string & tileUrlTemplate, int32_t zoomLevel): loader(loader), tileUrlTemplate(tileUrlTemplate), zoomLevel(zoomLevel) {}
@@ -115,9 +116,10 @@ std::vector<::VectorLayerFeatureCoordInfo> ReverseGeocoder::reverseGeocode(const
 
                     for (auto points: geometryHandler->getPointCoordinates()) {
                         for (auto point: points) {
-                            auto d = distance(converted4326, point);
+                            auto coord = Coord(CoordinateSystemIdentifiers::EPSG3857(), point.x, point.y, 0.0);
+                            auto d = distance(converted4326, coord);
                             if (d < thresholdMeters) {
-                                resultVector.push_back(VectorLayerFeatureCoordInfo(featureContext->getFeatureInfo(), point));
+                                resultVector.push_back(VectorLayerFeatureCoordInfo(featureContext->getFeatureInfo(), coord));
                             }
                         }
                     }


### PR DESCRIPTION
This PR replaces the storage of coordinates in the vector map. Currently, our vector map implementation only supports EPSG:3857 internally, so there is no need to store the system identifier and the Z value. The screenshot shows the profiling difference of the line tile.

before:
<img width="1600" alt="before" src="https://github.com/user-attachments/assets/f12aa278-5527-4e28-b1d3-4e4f58fe3110" />

after:
<img width="1393" alt="after" src="https://github.com/user-attachments/assets/0c31d022-1c68-48bf-97a1-38387b2ff53f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced map rendering with improved handling of varied coordinate data. This update refines how lines, symbols, and text features are positioned on maps.

- **Refactor**
  - Consolidated the coordinate conversion and rendering pipelines for both 2D and 3D data, resulting in a more consistent and precise display of map features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->