### PR TITLE
MAP-28: adds shards to SymbolAnimationCoordinatorMap

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test:
+    name: "Catch2 Tests"
     runs-on: ubuntu-latest
 
     steps:
@@ -30,7 +31,6 @@ jobs:
           mkdir test-results
           cd shared/test      # for access to data/ directory
           ../../build-debug/shared/test/tests \
-            --skip-benchmarks \
             -r JUnit::out=../../test-results/catch2-junit.xml \
             -r console::colour-mode=ansi
 

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,5 @@ DerivedData/
 ## clangd
 .cache/
 compile_commands.json
+
+cmake-build-test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,11 +6,19 @@ project(mapscore
 ####
 # mapscore OpenGL "proper", i.e. the C++ implementation without language bindings
 ####
-file(GLOB_RECURSE mapscore_SRC
-  "shared/public/*.cpp"
-  "shared/src/*.cpp"
-  "android/src/main/cpp/graphics/*.cpp"
-)
+if(APPLE)
+  file(GLOB_RECURSE mapscore_SRC
+          "shared/public/*.cpp"
+          "shared/src/*.cpp"
+  )
+else()
+  # Include Android-specific files only if not on Apple devices
+  file(GLOB_RECURSE mapscore_SRC
+          "shared/public/*.cpp"
+          "shared/src/*.cpp"
+          "android/src/main/cpp/graphics/*.cpp"
+  )
+endif()
 
 add_library(mapscore STATIC ${mapscore_SRC})
 
@@ -58,12 +66,18 @@ target_include_directories(mapscore PRIVATE
   shared/src/map/layers/text
   shared/src/map/scheduling
   shared/src/utils
-  android/src/main/cpp
-  android/src/main/cpp/graphics
-  android/src/main/cpp/graphics/objects
-  android/src/main/cpp/graphics/shader
-  android/src/main/cpp/utils
 )
+
+if(NOT APPLE)
+  target_include_directories(mapscore PRIVATE
+     android/src/main/cpp
+     android/src/main/cpp/graphics
+     android/src/main/cpp/graphics/objects
+     android/src/main/cpp/graphics/shader
+     android/src/main/cpp/utils
+  )
+endif()
+
 target_include_directories(mapscore PUBLIC
   shared/public
   external/djinni/support-lib/
@@ -75,7 +89,14 @@ set_property(
   PROPERTY COMPILE_DEFINITIONS
   $<$<CONFIG:Debug>:LOG_LEVEL=4>    # LogTrace
   $<$<CONFIG:Release>:LOG_LEVEL=1>) # LogWarning
-target_compile_definitions(mapscore PRIVATE OPENMOBILEMAPS_GL=1)
+
+
+if(APPLE)
+  target_compile_definitions(mapscore PRIVATE CATCH_TESTING=1)
+else()
+  target_compile_definitions(mapscore PRIVATE OPENMOBILEMAPS_GL=1)
+endif()
+
 target_compile_features(mapscore PRIVATE cxx_std_20)
 target_compile_options(mapscore PRIVATE -Werror -Wno-deprecated -Wno-reorder -fPIC) # fPIC so we can "embed" into shared mapscore_jni
 target_link_libraries(mapscore ${OPENGL_LIBRARIES})

--- a/shared/src/logger/Logger.cpp
+++ b/shared/src/logger/Logger.cpp
@@ -24,7 +24,7 @@ int __android_log_print(int prio, const char *tag, const char *fmt, ...);
 }
 #endif
 
-#if defined(__APPLE__) && !defined(BANDIT_TESTING)
+#if defined(__APPLE__) && !defined(CATCH_TESTING)
 #include <os/log.h>
 #endif
 
@@ -75,7 +75,7 @@ void Logger::log(int prio, const char *tag, const char *fmt, ...) const {
     va_end(args);
 #endif
 
-#if (defined(__APPLE__) && !defined(BANDIT_TESTING)) || defined(_WIN32)
+#if (defined(__APPLE__) && !defined(CATCH_TESTING)) || defined(_WIN32)
     switch (priority) {
     case 0: {
         os_log(OS_LOG_DEFAULT, "%{public}s", fmt);
@@ -103,7 +103,7 @@ void Logger::log(int prio, const char *tag, const char *fmt, ...) const {
     }
 #endif
 
-#if defined(BANDIT_TESTING) || (defined(__linux__) && !defined(__ANDROID__))
+#if defined(CATCH_TESTING) || (defined(__linux__) && !defined(__ANDROID__))
     if (priority <= LOG_LEVEL) {
         switch (priority) {
         case 0: {

--- a/shared/src/map/layers/tiled/vector/symbol/SymbolAnimationCoordinatorMap.h
+++ b/shared/src/map/layers/tiled/vector/symbol/SymbolAnimationCoordinatorMap.h
@@ -28,7 +28,7 @@ struct CoordinatorXCompare {
 
 class SymbolAnimationCoordinatorMap {
 public:
-    SymbolAnimationCoordinatorMap(size_t numShards = 32) : numShards(numShards), shards(numShards) {}
+    SymbolAnimationCoordinatorMap() {}
 
     std::shared_ptr<SymbolAnimationCoordinator> getOrAddAnimationController(size_t crossTileIdentifier,
                                                                             const Coord &coord,
@@ -149,7 +149,7 @@ private:
     };
 
     bool animationsEnabled = true;
-    size_t numShards;
-    std::vector<Shard> shards;
+    static constexpr size_t numShards = 32;
+    std::array<Shard, numShards> shards;
     std::hash<size_t> hash;
 };

--- a/shared/src/map/layers/tiled/vector/symbol/SymbolAnimationCoordinatorMap.h
+++ b/shared/src/map/layers/tiled/vector/symbol/SymbolAnimationCoordinatorMap.h
@@ -11,6 +11,13 @@
 #pragma once
 
 #include "SymbolAnimationCoordinator.h"
+#include <mutex>
+#include <unordered_map>
+#include <map>
+#include <set>
+#include <memory>
+#include <vector>
+#include <functional>
 
 struct CoordinatorXCompare {
     bool operator() (const std::shared_ptr<SymbolAnimationCoordinator> &a, const std::shared_ptr<SymbolAnimationCoordinator> &b) const {
@@ -20,6 +27,7 @@ struct CoordinatorXCompare {
 
 class SymbolAnimationCoordinatorMap {
 public:
+    SymbolAnimationCoordinatorMap(size_t numShards = 32) : numShards(numShards), shards(numShards) {}
 
     std::shared_ptr<SymbolAnimationCoordinator> getOrAddAnimationController(size_t crossTileIdentifier,
                                                                             const Coord &coord,
@@ -28,12 +36,14 @@ public:
                                                                             double yTolerance,
                                                                             const int64_t animationDuration,
                                                                             const int64_t animationDelay) {
-        std::lock_guard<std::mutex> lock(mapMutex);
-        auto coordinatorIt = animationCoordinators.find(crossTileIdentifier);
-        if (coordinatorIt != animationCoordinators.end()) {
+        size_t shardIndex = hash(crossTileIdentifier) % numShards;
+        auto &shard = shards[shardIndex];
+        std::lock_guard<std::mutex> lock(shard.mutex);
+
+        auto coordinatorIt = shard.animationCoordinators.find(crossTileIdentifier);
+        if (coordinatorIt != shard.animationCoordinators.end()) {
             for (auto &[levelZoomIdentifier, coordinators]: coordinatorIt->second) {
-                size_t numElements = coordinators.size();
-                if (levelZoomIdentifier == zoomIdentifier && numElements <= MIN_NUM_SEARCH) {
+                if (levelZoomIdentifier == zoomIdentifier) {
                     // limit comparisons with equal zoomIdentifier entries
                     continue;
                 }
@@ -41,15 +51,12 @@ public:
                 double toleranceFactor = 1 << std::max(0, levelZoomIdentifier - zoomIdentifier);
                 double maxXTolerance = toleranceFactor * xTolerance;
 
-                std::set<std::shared_ptr<SymbolAnimationCoordinator>, CoordinatorXCompare>::const_iterator targetIt = coordinators.begin();
-                if (numElements > MIN_NUM_SEARCH) {
-                    targetIt = std::lower_bound(coordinators.begin(),
-                                                coordinators.end(),
-                                                coord.x,
-                                                [](const std::shared_ptr<SymbolAnimationCoordinator> &a, const double &value) {
-                                                    return a->coordinate.x < value;
-                                                });
-                }
+                auto targetIt = std::lower_bound(coordinators.begin(),
+                                            coordinators.end(),
+                                            coord.x,
+                                            [](const std::shared_ptr<SymbolAnimationCoordinator> &a, const double &value) {
+                                                return a->coordinate.x < value;
+                                            });
 
                 while (targetIt != coordinators.end()) {
                     if (targetIt->get()->isMatching(coord, zoomIdentifier)) {
@@ -75,17 +82,19 @@ public:
         newSet.insert(animationCoordinator);
         std::map<int, std::set<std::shared_ptr<SymbolAnimationCoordinator>, CoordinatorXCompare>> newMap;
         newMap.insert(std::make_pair(zoomIdentifier, newSet));
-        animationCoordinators.insert({crossTileIdentifier, newMap});
+        shard.animationCoordinators.insert({crossTileIdentifier, newMap});
         return animationCoordinator;
     }
 
     bool isAnimating() {
-        std::lock_guard<std::mutex> lock(mapMutex);
-        for (const auto &[id, coordinators]: animationCoordinators) {
-            for (const auto &[levelZoomIdentifier, coordinatorSet]: coordinators) {
-                for (const auto &coordinator: coordinatorSet) {
-                    if (coordinator->isAnimating()) {
-                        return true;
+        for (auto &shard : shards) {
+            std::lock_guard<std::mutex> lock(shard.mutex);
+            for (const auto &[id, coordinators]: shard.animationCoordinators) {
+                for (const auto &[levelZoomIdentifier, coordinatorSet]: coordinators) {
+                    for (const auto &coordinator: coordinatorSet) {
+                        if (coordinator->isAnimating()) {
+                            return true;
+                        }
                     }
                 }
             }
@@ -94,45 +103,52 @@ public:
     }
 
     void clearAnimationCoordinators() {
-        std::lock_guard<std::mutex> lock(mapMutex);
-        for (auto it = animationCoordinators.begin(), next_it = it; it != animationCoordinators.end(); it = next_it) {
-            ++next_it;
-            for (auto setIt = it->second.begin(), nextSetIt = setIt; setIt != it->second.end(); setIt = nextSetIt) {
-                ++nextSetIt;
-                for (auto coordsIt = setIt->second.begin(); coordsIt != setIt->second.end();) {
-                    if (!coordsIt->get()->isUsed()) {
-                        coordsIt = setIt->second.erase(coordsIt);
-                    } else {
-                        ++coordsIt;
+        for (auto &shard : shards) {
+            std::lock_guard<std::mutex> lock(shard.mutex);
+            for (auto it = shard.animationCoordinators.begin(), next_it = it; it != shard.animationCoordinators.end(); it = next_it) {
+                ++next_it;
+                for (auto setIt = it->second.begin(), nextSetIt = setIt; setIt != it->second.end(); setIt = nextSetIt) {
+                    ++nextSetIt;
+                    for (auto coordsIt = setIt->second.begin(); coordsIt != setIt->second.end();) {
+                        if (!coordsIt->get()->isUsed()) {
+                            coordsIt = setIt->second.erase(coordsIt);
+                        } else {
+                            ++coordsIt;
+                        }
+                    }
+                    if (setIt->second.empty()) {
+                        it->second.erase(setIt);
                     }
                 }
-                if (setIt->second.empty()) {
-                    it->second.erase(setIt);
+                if (it->second.empty()) {
+                    shard.animationCoordinators.erase(it);
                 }
-            }
-            if (it->second.empty()) {
-                animationCoordinators.erase(it);
             }
         }
     }
 
     void enableAnimations(bool enabled) {
         animationsEnabled = enabled;
-        std::lock_guard<std::mutex> lock(mapMutex);
-        for (const auto &[_, coordinatorMap] : animationCoordinators) {
-            for (const auto &[_, coordinatorSet] : coordinatorMap) {
-                for (const auto &coordinator : coordinatorSet) {
-                    coordinator->enableAnimations(enabled);
+        for (auto &shard : shards) {
+            std::lock_guard<std::mutex> lock(shard.mutex);
+            for (const auto &[_, coordinatorMap] : shard.animationCoordinators) {
+                for (const auto &[_, coordinatorSet] : coordinatorMap) {
+                    for (const auto &coordinator : coordinatorSet) {
+                        coordinator->enableAnimations(enabled);
+                    }
                 }
             }
         }
     }
 
 private:
-    static const size_t MIN_NUM_SEARCH = 9;
+    struct Shard {
+        std::mutex mutex;
+        std::unordered_map<size_t, std::map<int, std::set<std::shared_ptr<SymbolAnimationCoordinator>, CoordinatorXCompare>>> animationCoordinators;
+    };
 
     bool animationsEnabled = true;
-
-    std::mutex mapMutex;
-    std::unordered_map<size_t, std::map<int, std::set<std::shared_ptr<SymbolAnimationCoordinator>, CoordinatorXCompare>>> animationCoordinators;
+    size_t numShards;
+    std::vector<Shard> shards;
+    std::hash<size_t> hash;
 };

--- a/shared/src/map/layers/tiled/vector/symbol/SymbolAnimationCoordinatorMap.h
+++ b/shared/src/map/layers/tiled/vector/symbol/SymbolAnimationCoordinatorMap.h
@@ -18,6 +18,7 @@
 #include <memory>
 #include <vector>
 #include <functional>
+#include <algorithm>
 
 struct CoordinatorXCompare {
     bool operator() (const std::shared_ptr<SymbolAnimationCoordinator> &a, const std::shared_ptr<SymbolAnimationCoordinator> &b) const {

--- a/shared/test/CMakeLists.txt
+++ b/shared/test/CMakeLists.txt
@@ -10,6 +10,7 @@ FetchContent_MakeAvailable(Catch2)
 add_executable(tests 
   "TestActor.cpp"
   "TestGeoJsonParser.cpp"
+  "TestSymbolAnimationCoordinatorMap.cpp"
 )
 # Use mapscore _private_ include to allow testing functionality declared in internal headers.
 target_include_directories(tests PRIVATE

--- a/shared/test/TestSymbolAnimationCoordinatorMap.cpp
+++ b/shared/test/TestSymbolAnimationCoordinatorMap.cpp
@@ -4,6 +4,7 @@
 #include <atomic>
 #include <catch2/benchmark/catch_benchmark.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_get_random_seed.hpp>
 #include <fstream>
 #include <iostream>
 #include <random>
@@ -156,8 +157,7 @@ TEST_CASE("SymbolAnimationCoordinatorMap with multiple threads") {
         SymbolAnimationCoordinatorMap coordinatorMap;
 
         auto threadFunc = [&coordinatorMap, &counter, &runCount, &logEntries](size_t threadIndex, size_t numThreads) {
-            std::random_device rd;
-            std::mt19937 g(rd());
+            std::mt19937 g(Catch::getSeed());
             std::uniform_int_distribution<size_t> dist(0, logEntries.size() - 1);
 
             for (int run = 0; run < runCount; ++run) {

--- a/shared/test/TestSymbolAnimationCoordinatorMap.cpp
+++ b/shared/test/TestSymbolAnimationCoordinatorMap.cpp
@@ -1,0 +1,190 @@
+#include "SymbolAnimationCoordinatorMap.h"
+
+#include <algorithm>
+#include <atomic>
+#include <catch2/benchmark/catch_benchmark.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <fstream>
+#include <iostream>
+#include <random>
+#include <thread>
+#include <vector>
+
+// Function to read the log file and parse the arguments
+std::vector<std::tuple<size_t, Coord, int, double, double, int64_t, int64_t>> readLogFile(const std::string &filename) {
+    std::vector<std::tuple<size_t, Coord, int, double, double, int64_t, int64_t>> logEntries;
+    std::ifstream file(filename);
+    std::string line;
+
+    std::string threadIdLabel, crossTileIdentifierLabel, coordLabel, zoomIdentifierLabel, xToleranceLabel, yToleranceLabel, animationDurationLabel, animationDelayLabel;
+    size_t crossTileIdentifier;
+    int32_t coordX;
+    double coordY;
+    int zoomIdentifier;
+    double xTolerance, yTolerance;
+    int64_t animationDuration, animationDelay;
+
+    std::vector<std::string> tokens;
+
+    while (std::getline(file, line)) {
+        std::istringstream iss(line);
+        std::string token;
+        tokens.clear();
+        while (std::getline(iss, token, ',')) {
+            tokens.push_back(token);
+        }
+
+        if (tokens.size() == 8) {
+            // Remove labels and parse values
+            crossTileIdentifier = std::stoull(tokens[1].substr(tokens[1].find(":") + 1));
+            coordX = std::stoi(tokens[2].substr(tokens[2].find("(") + 1, tokens[2].find(";") - tokens[2].find("(") - 1));
+            coordY = std::stod(tokens[2].substr(tokens[2].find(";") + 1, tokens[2].find(")") - tokens[2].find(";") - 1));
+            zoomIdentifier = std::stoi(tokens[3].substr(tokens[3].find(":") + 1));
+            xTolerance = std::stod(tokens[4].substr(tokens[4].find(":") + 1));
+            yTolerance = std::stod(tokens[5].substr(tokens[5].find(":") + 1));
+            animationDuration = std::stoll(tokens[6].substr(tokens[6].find(":") + 1));
+            animationDelay = std::stoll(tokens[7].substr(tokens[7].find(":") + 1));
+
+            logEntries.emplace_back(crossTileIdentifier, Coord{coordX, coordY, 0, 0}, zoomIdentifier, xTolerance, yTolerance, animationDuration, animationDelay);
+        }
+    }
+
+    return logEntries;
+}
+
+TEST_CASE("functionality") {
+    SymbolAnimationCoordinatorMap coordinatorMap;
+
+    SECTION("return same coordinator") {
+        std::shared_ptr<SymbolAnimationCoordinator> first, second;
+        {
+            first = coordinatorMap.getOrAddAnimationController(0, Coord(0, 0, 0, 0), 0, 0.0, 0.0, 10, 0);
+            first->getIconAlpha(0.5, 10);
+            first->getIconAlpha(0.5, 20);
+            REQUIRE(first->getIconAlpha(1.0, 20) == 0.5);
+        }
+
+        {
+            second = coordinatorMap.getOrAddAnimationController(0, Coord(0, 0, 0, 0), 1, 0.0, 0.0, 10, 0);
+            REQUIRE(second->getIconAlpha(1.0, 20) == 0.5);
+        }
+
+        REQUIRE(first == second);
+    }
+
+    SECTION("return different coordinators for different crossTileIdentifiers") {
+        auto first = coordinatorMap.getOrAddAnimationController(1, Coord(0, 0, 0, 0), 0, 0.0, 0.0, 10, 0);
+        auto second = coordinatorMap.getOrAddAnimationController(2, Coord(0, 0, 0, 0), 1, 0.0, 0.0, 10, 0);
+        REQUIRE(first != second);
+    }
+
+    SECTION("return different coordinator for same crossTileIdentifier and zoomIdentifier") {
+        auto first = coordinatorMap.getOrAddAnimationController(1, Coord(0, 0, 0, 0), 0, 0.0, 0.0, 10, 0);
+        auto second = coordinatorMap.getOrAddAnimationController(1, Coord(0, 0, 0, 0), 0, 0.0, 0.0, 10, 0);
+        REQUIRE(first != second);
+    }
+
+    SECTION("return same coordinators for same crossTileIdentifier but different zoomIdentifiers") {
+        auto first = coordinatorMap.getOrAddAnimationController(1, Coord(0, 0, 0, 0), 0, 0.0, 0.0, 10, 0);
+        auto second = coordinatorMap.getOrAddAnimationController(1, Coord(0, 0, 0, 0), 1, 0.0, 0.0, 10, 0);
+        REQUIRE(first == second);
+    }
+
+    SECTION("clearAnimationCoordinators removes unused coordinators") {
+        auto first = coordinatorMap.getOrAddAnimationController(1, Coord(0, 0, 0, 0), 0, 0.0, 0.0, 10, 0);
+        coordinatorMap.clearAnimationCoordinators();
+        auto second = coordinatorMap.getOrAddAnimationController(1, Coord(0, 0, 0, 0), 1, 0.0, 0.0, 10, 0);
+        REQUIRE(first != second);
+    }
+
+    SECTION("clearAnimationCoordinators removes only unused coordinators") {
+        auto first = coordinatorMap.getOrAddAnimationController(1, Coord(0, 0, 0, 0), 0, 0.0, 0.0, 10, 0);
+        first->increaseUsage();
+        coordinatorMap.clearAnimationCoordinators();
+        auto second = coordinatorMap.getOrAddAnimationController(1, Coord(0, 0, 0, 0), 1, 0.0, 0.0, 10, 0);
+        REQUIRE(first == second);
+    }
+};
+
+TEST_CASE("SymbolAnimationCoordinatorMap with multiple threads") {
+
+    BENCHMARK("Benchmark random data") {
+        std::atomic<size_t> counter{0};
+        int callsNum = 1000;
+        size_t numThreads = std::thread::hardware_concurrency();
+
+        SymbolAnimationCoordinatorMap coordinatorMap;
+
+        auto threadFunc = [&coordinatorMap, &counter, &callsNum](size_t threadIndex) {
+            for (size_t i = 0; i < callsNum; ++i) {
+                size_t crossTileIdentifier = threadIndex * 1000 + i;
+                Coord coord{static_cast<int32_t>(static_cast<double>(threadIndex)), static_cast<double>(i), 0, 0};
+                int zoomIdentifier = static_cast<int>(threadIndex % 10);
+                double xTolerance = 0.1;
+                double yTolerance = 0.1;
+                int64_t animationDuration = 300;
+                int64_t animationDelay = 0;
+
+                coordinatorMap.getOrAddAnimationController(crossTileIdentifier, coord, zoomIdentifier, xTolerance, yTolerance,
+                                                           animationDuration, animationDelay);
+                ++counter;
+            }
+        };
+
+        std::vector<std::thread> threads;
+
+        for (size_t i = 0; i < numThreads; ++i) {
+            threads.emplace_back(threadFunc, i);
+        }
+
+        for (auto &thread : threads) {
+            thread.join();
+        }
+
+        REQUIRE(counter == numThreads * callsNum);
+    };
+
+
+    auto logEntries = readLogFile("data/symbolAnimationCoordinator/recording.txt");
+
+    BENCHMARK("Simulate from log file") {
+        std::atomic<size_t> counter{0};
+        size_t numThreads = std::thread::hardware_concurrency();
+
+        int runCount = 1;
+
+        SymbolAnimationCoordinatorMap coordinatorMap;
+
+        auto threadFunc = [&coordinatorMap, &counter, &runCount, &logEntries](size_t threadIndex, size_t numThreads) {
+            std::random_device rd;
+            std::mt19937 g(rd());
+            std::uniform_int_distribution<size_t> dist(0, logEntries.size() - 1);
+
+            for (int run = 0; run < runCount; ++run) {
+                for (size_t i = threadIndex; i < logEntries.size(); i += numThreads) {
+                    size_t randomIndex = dist(g);
+                    auto &[crossTileIdentifier, coord, zoomIdentifier, xTolerance, yTolerance, animationDuration, animationDelay] =
+                        logEntries[randomIndex];
+                    coordinatorMap.getOrAddAnimationController(crossTileIdentifier, coord, zoomIdentifier, xTolerance, yTolerance,
+                                                               animationDuration, animationDelay);
+                    ++counter;
+                }
+            }
+        };
+
+        std::vector<std::thread> threads;
+
+        for (size_t i = 0; i < numThreads; ++i) {
+            threads.emplace_back(threadFunc, i, numThreads);
+        }
+
+        for (auto &thread : threads) {
+            thread.join();
+        }
+
+        REQUIRE(!logEntries.empty());
+        REQUIRE(counter == logEntries.size() * runCount);
+
+        return counter == runCount;
+    };
+}


### PR DESCRIPTION
This PR adds Catch2 tests for the SymbolAnimationCoordinatorMap and fixes the test build for macOS.
With reproducible test cases, we now have a measurable benchmark. Additionally, I added shared ownership to the SymbolAnimationCoordinatorMap, which improves runtime performance.

before:

```
benchmark name                       samples       iterations    est run time
                                     mean          low mean      high mean
                                     std dev       low std dev   high std dev
-------------------------------------------------------------------------------
Benchmark random data                          100             1     4.15799 s 
                                        42.7119 ms     42.093 ms    44.6054 ms 
                                        4.98408 ms    1.84416 ms    10.8426 ms 
                                                                               
Simulate from log file                         100             1      21.509 s 
                                        211.488 ms    210.565 ms    212.385 ms 
                                        4.62717 ms    4.05888 ms    5.35695 ms 
```

after:

```
benchmark name                       samples       iterations    est run time
                                     mean          low mean      high mean
                                     std dev       low std dev   high std dev
-------------------------------------------------------------------------------
Benchmark random data                          100             1    940.766 ms 
                                        9.66332 ms    9.60304 ms    9.74142 ms 
                                        347.726 us    278.248 us    449.302 us 
                                                                               
Simulate from log file                         100             1     7.57967 s 
                                        74.5258 ms    72.4308 ms    77.2266 ms 
                                        12.0686 ms    9.43013 ms    16.1592 ms 
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the `.gitignore` file to exclude the `cmake-build-test` directory.
	- Simplified platform-specific build settings in the `CMakeLists.txt` for better management of source files and include directories.
- **Tests**
	- Added comprehensive tests for the `SymbolAnimationCoordinatorMap`, including functionality and performance under concurrent conditions.
	- Updated GitHub Actions workflow to include benchmarks in the test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->