### PR TITLE
Reuse earcut internal Node allocations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/UbiqueInnovation/djinni.git
 [submodule "external/earcut/earcut"]
 	path = external/earcut/earcut
-	url = https://github.com/mapbox/earcut.hpp.git
+	url = https://github.com/matzf/earcut.hpp.git
 [submodule "external/protozero/protozero"]
 	path = external/protozero/protozero
 	url = https://github.com/mapbox/protozero.git

--- a/shared/src/map/layers/objects/Polygon2dLayerObject.cpp
+++ b/shared/src/map/layers/objects/Polygon2dLayerObject.cpp
@@ -43,6 +43,7 @@ void Polygon2dLayerObject::setPolygons(const std::vector<PolygonCoord> &polygons
     size_t totalPoints = 0;
 
     std::vector<Vec2D> vecVertices;
+    mapbox::detail::Earcut<int32_t> earcutter;
 
     BoundingBox bbox = BoundingBox(CoordinateSystemIdentifiers::RENDERSYSTEM());
     for (auto const &polygon : polygons) {
@@ -63,7 +64,8 @@ void Polygon2dLayerObject::setPolygons(const std::vector<PolygonCoord> &polygons
             }
             renderCoords.push_back(holeCoords);
         }
-        std::vector<int32_t> curIndices = mapbox::earcut<int32_t>(renderCoords);
+        earcutter(renderCoords);
+        std::vector<int32_t> curIndices = std::move(earcutter.indices);
 
         for (auto const &index : curIndices) {
             indices.push_back(indexOffset + index);

--- a/shared/src/map/layers/objects/PolygonMaskObject.cpp
+++ b/shared/src/map/layers/objects/PolygonMaskObject.cpp
@@ -46,6 +46,7 @@ void PolygonMaskObject::setPolygons(const std::vector<::PolygonCoord> &polygons,
     int32_t indexOffset = 0;
 
     std::vector<Vec2D> vecVertices;
+    mapbox::detail::Earcut<int32_t> earcutter;
 
     for (auto const &polygon : polygons) {
         std::vector<std::vector<Vec2D>> renderCoords;
@@ -64,7 +65,8 @@ void PolygonMaskObject::setPolygons(const std::vector<::PolygonCoord> &polygons,
             }
             renderCoords.push_back(holeCoords);
         }
-        std::vector<int32_t> curIndices = mapbox::earcut<int32_t>(renderCoords);
+        earcutter(renderCoords);
+        std::vector<int32_t> curIndices = std::move(earcutter.indices);
 
         for (auto const &index : curIndices) {
             indices.push_back(indexOffset + index);

--- a/shared/src/map/layers/tiled/vector/Tiled2dMapVectorSource.cpp
+++ b/shared/src/map/layers/tiled/vector/Tiled2dMapVectorSource.cpp
@@ -67,6 +67,7 @@ Tiled2dMapVectorTileInfo::FeatureMap Tiled2dMapVectorSource::postLoadingTask(std
     try {
         vtzero::vector_tile tileData((char*)loadedData->data->buf(), loadedData->data->len());
 
+        mapbox::detail::Earcut<uint16_t> earcutter;
         while (auto layer = tileData.next_layer()) {
             std::string sourceLayerName = std::string(layer.name());
             if ((layersToDecode.empty() || layersToDecode.count(sourceLayerName) > 0) && !layer.empty()) {
@@ -95,7 +96,7 @@ Tiled2dMapVectorTileInfo::FeatureMap Tiled2dMapVectorSource::postLoadingTask(std
                                     return std::make_shared<std::unordered_map<std::string, std::shared_ptr<std::vector<Tiled2dMapVectorTileInfo::FeatureTuple>>>>();
                                 }
                             }
-                            geometryHandler->triangulatePolygons(i);
+                            geometryHandler->triangulatePolygons(i, earcutter);
                         }
 
                         geometryHandler->endTringulatePolygons();


### PR DESCRIPTION
Reuse detail::Earcutter object and its internal allocations.

Modified earcut library -- for now in my personal fork. Should we move this under openmobilemaps? Or try to upstream the change before using it?

Also, reserve space for output coordinates before push_back in triangulatePolygons/triangulateGeoJsonPolygons.