### PR TITLE
Load test data independent of working directory 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,9 +29,8 @@ jobs:
       - name: Test
         run: |
           mkdir test-results
-          cd shared/test      # for access to data/ directory
-          ../../build-debug/shared/test/tests \
-            -r JUnit::out=../../test-results/catch2-junit.xml \
+          build-debug/shared/test/tests \
+            -r JUnit::out=test-results/catch2-junit.xml \
             -r console::colour-mode=ansi
 
       - name: Postprocess Junit XML

--- a/shared/test/CMakeLists.txt
+++ b/shared/test/CMakeLists.txt
@@ -12,13 +12,19 @@ add_executable(tests
   "TestGeoJsonParser.cpp"
   "TestSymbolAnimationCoordinatorMap.cpp"
   "TestGeometryHandler.cpp"
+  "helper/TestData.cpp"
 )
 # Use mapscore _private_ include to allow testing functionality declared in internal headers.
 target_include_directories(tests PRIVATE
   "$<TARGET_PROPERTY:mapscore,INCLUDE_DIRECTORIES>"
 )
+cmake_path(SET TESTDATA_DIR "data/")
+cmake_path(ABSOLUTE_PATH TESTDATA_DIR NORMALIZE)
 target_link_libraries(tests PRIVATE Catch2::Catch2WithMain mapscore)
-target_compile_definitions(tests PRIVATE OPENMOBILEMAPS_GL=1)
+target_compile_definitions(tests PRIVATE 
+  OPENMOBILEMAPS_GL=1
+  OPENMOBILEMAPS_TESTDATA_DIR=${TESTDATA_DIR}
+)
 target_compile_features(tests PRIVATE cxx_std_20)
 target_compile_options(tests PRIVATE -Werror -Wno-deprecated)
 

--- a/shared/test/TestGeometryHandler.cpp
+++ b/shared/test/TestGeometryHandler.cpp
@@ -14,7 +14,7 @@
 #include <thread>
 #include <vector>
 
-std::pair<char*, std::size_t> readFile(const std::string& filePath) {
+std::vector<char> readFile(const std::string& filePath) {
     std::ifstream file(filePath, std::ios::binary | std::ios::ate);
     if (!file) {
         throw std::runtime_error("Unable to open file");
@@ -23,13 +23,12 @@ std::pair<char*, std::size_t> readFile(const std::string& filePath) {
     std::size_t fileSize = file.tellg();
     file.seekg(0, std::ios::beg);
 
-    char* buffer = new char[fileSize];
-    if (!file.read(buffer, fileSize)) {
-        delete[] buffer;
+    std::vector<char> buffer(fileSize);
+    if (!file.read(buffer.data(), fileSize)) {
         throw std::runtime_error("Error reading file");
     }
 
-    return {buffer, fileSize};
+    return buffer;
 }
 
 struct ParsingResult {
@@ -38,47 +37,49 @@ struct ParsingResult {
     size_t lineCount;
 };
 
-void parseAndTriangulate(const std::string& filePath, ParsingResult expectedResult) {
+void parseAndTriangulate(const std::string& filePath, ParsingResult expectedResult, Catch::Benchmark::Chronometer meter) {
     ::RectCoord tileCoords = {Coord(3857,1224991.657211,6287508.342789,0), Coord(3857,1849991.657211,5662508.342789,0)};
     const std::optional<Tiled2dMapVectorSettings> vectorSettings = std::nullopt;
     const std::shared_ptr<CoordinateConversionHelperInterface> conversionHelper = CoordinateConversionHelperInterface::independentInstance();
 
     conversionHelper->registerConverter(std::make_shared<DefaultSystemToRenderConverter>(CoordinateSystemFactory::getEpsg3857System(), false));
 
-    auto [dataPtr, dataSize] = readFile(filePath);
+    auto data= readFile(filePath);
 
     ParsingResult result = {0, 0, 0};
 
-    vtzero::vector_tile tileData(dataPtr, dataSize);
-    while (auto layer = tileData.next_layer()) {
-        std::string sourceLayerName = std::string(layer.name());
+    meter.measure([&](int run) {
+        vtzero::vector_tile tileData(data.data(), data.size());
+        while (auto layer = tileData.next_layer()) {
+            std::string sourceLayerName = std::string(layer.name());
 
-        while (const auto &feature = layer.next_feature()) {
-            int extent = (int) layer.extent();
-            auto const featureContext = std::make_shared<FeatureContext>(feature);
-            VectorTileGeometryHandler geometryHandler = VectorTileGeometryHandler(tileCoords, extent, std::nullopt, conversionHelper);
-            decode_geometry(feature.geometry(), geometryHandler);
-            size_t polygonCount = geometryHandler.beginTriangulatePolygons();
-            for (size_t i = 0; i < polygonCount; i++) {
-                geometryHandler.triangulatePolygons(i);
+            while (const auto &feature = layer.next_feature()) {
+                int extent = (int) layer.extent();
+                auto const featureContext = std::make_shared<FeatureContext>(feature);
+                VectorTileGeometryHandler geometryHandler = VectorTileGeometryHandler(tileCoords, extent, std::nullopt, conversionHelper);
+                decode_geometry(feature.geometry(), geometryHandler);
+                size_t polygonCount = geometryHandler.beginTriangulatePolygons();
+                for (size_t i = 0; i < polygonCount; i++) {
+                    geometryHandler.triangulatePolygons(i);
+                }
+                geometryHandler.endTringulatePolygons();
+                result.polygonCount += geometryHandler.getPolygons().size();
+                result.pointCount += geometryHandler.getPointCoordinates().size();
+                result.lineCount += geometryHandler.getLineCoordinates().size();
             }
-            geometryHandler.endTringulatePolygons();
-            result.polygonCount += geometryHandler.getPolygons().size();
-            result.pointCount += geometryHandler.getPointCoordinates().size();
-            result.lineCount += geometryHandler.getLineCoordinates().size();
         }
-    }
+    });
 
-    CHECK(result.polygonCount == expectedResult.polygonCount);
-    CHECK(result.pointCount == expectedResult.pointCount);
-    CHECK(result.lineCount == expectedResult.lineCount);
+    CHECK(result.polygonCount == meter.runs() * expectedResult.polygonCount);
+    CHECK(result.pointCount == meter.runs() * expectedResult.pointCount);
+    CHECK(result.lineCount == meter.runs() * expectedResult.lineCount);
 }
 
 TEST_CASE("VectorTileGeometryHandler") {
-    BENCHMARK("Benchmark regular") {
-        parseAndTriangulate("data/tiles/reg.pbf", ParsingResult{318,3336,3336});
+    BENCHMARK_ADVANCED("Benchmark regular")(Catch::Benchmark::Chronometer meter) {
+        return parseAndTriangulate("data/tiles/reg.pbf", ParsingResult{318,3336,3336}, meter);
     };
-    BENCHMARK("Benchmark relief") {
-        parseAndTriangulate("data/tiles/relief.pbf", ParsingResult{24345,34413,34413});
+    BENCHMARK_ADVANCED("Benchmark relief")(Catch::Benchmark::Chronometer meter) {
+        parseAndTriangulate("data/tiles/relief.pbf", ParsingResult{24345,34413,34413}, meter);
     };
 }

--- a/shared/test/TestSymbolAnimationCoordinatorMap.cpp
+++ b/shared/test/TestSymbolAnimationCoordinatorMap.cpp
@@ -1,20 +1,20 @@
 #include "SymbolAnimationCoordinatorMap.h"
+#include "helper/TestData.h"
 
-#include <algorithm>
-#include <atomic>
 #include <catch2/benchmark/catch_benchmark.hpp>
-#include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_get_random_seed.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <atomic>
 #include <fstream>
-#include <iostream>
 #include <random>
 #include <thread>
 #include <vector>
 
 // Function to read the log file and parse the arguments
-std::vector<std::tuple<size_t, Vec2D, int, double, double, int64_t, int64_t>> readLogFile(const std::string &filename) {
+std::vector<std::tuple<size_t, Vec2D, int, double, double, int64_t, int64_t>> readLogFile(const char *filename) {
     std::vector<std::tuple<size_t, Vec2D, int, double, double, int64_t, int64_t>> logEntries;
-    std::ifstream file(filename);
+    std::ifstream file(TestData::resolve(filename));
     std::string line;
 
     std::string threadIdLabel, crossTileIdentifierLabel, coordLabel, zoomIdentifierLabel, xToleranceLabel, yToleranceLabel, animationDurationLabel, animationDelayLabel;
@@ -146,7 +146,7 @@ TEST_CASE("SymbolAnimationCoordinatorMap with multiple threads") {
     };
 
 
-    auto logEntries = readLogFile("data/symbolAnimationCoordinator/recording.txt");
+    auto logEntries = readLogFile("symbolAnimationCoordinator/recording.txt");
 
     BENCHMARK("Simulate from log file") {
         std::atomic<size_t> counter{0};

--- a/shared/test/helper/TestData.cpp
+++ b/shared/test/helper/TestData.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025 Ubique Innovation AG <https://www.ubique.ch>
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ *  SPDX-License-Identifier: MPL-2.0
+ */
+
+#include "TestData.h"
+
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+
+#ifdef OPENMOBILEMAPS_TESTDATA_DIR_
+#define xstr(X) str(X)
+#define str(X) #X
+// Absolute path to data/ dir. Set from build system.
+static const char *TESTDATA_DIR = xstr(OPENMOBILEMAPS_TESTDATA_DIR);
+#else
+// Absolute path to data/ dir. Defined relative to this file; usually works but
+// __FILE__ is not guaranteed to contain an absolute path.
+static const char *TESTDATA_DIR = __FILE__ "../../../data";
+#endif
+
+static std::filesystem::path getTestdataDir() {
+    const char *testdataDirEnv = getenv("OPENMOBILEMAPS_TESTDATA_DIR");
+    if (testdataDirEnv) {
+        std::cerr << "Testdata directory set from envvar OPENMOBILEMAPS_TESTDATA_DIR=" << testdataDirEnv << std::endl;
+    }
+    const char *testdataDir = testdataDirEnv ? testdataDirEnv : TESTDATA_DIR;
+    return std::filesystem::path(testdataDir).lexically_normal();
+}
+
+std::string TestData::resolve(const char *relPath) {
+    static std::filesystem::path testdataDir = getTestdataDir();
+    return testdataDir / std::filesystem::path(relPath);
+}
+
+std::string TestData::readFileToString(const char *relPath) {
+    std::string filePath = resolve(relPath);
+    std::ifstream file{filePath};
+    if (!file) {
+        throw std::runtime_error(std::string("Unable to open file ") + filePath + ": " + strerror(errno));
+    }
+    std::string content{std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
+    if (file.fail()) {
+        throw std::runtime_error(std::string("Error reading file ") + filePath + ": " + strerror(errno));
+    }
+    return content;
+}
+
+std::vector<char> TestData::readFileToBuffer(const char *relPath) {
+    std::string filePath = resolve(relPath);
+    std::ifstream file(filePath, std::ios::binary | std::ios::ate);
+    if (!file) {
+        throw std::runtime_error(std::string("Unable to open file ") + filePath + ": " + strerror(errno));
+    }
+
+    std::size_t fileSize = file.tellg();
+    file.seekg(0, std::ios::beg);
+
+    std::vector<char> buffer(fileSize);
+    if (!file.read(buffer.data(), fileSize)) {
+        throw std::runtime_error(std::string("Error reading file ") + filePath + ": " + strerror(errno));
+    }
+
+    return buffer;
+}

--- a/shared/test/helper/TestData.h
+++ b/shared/test/helper/TestData.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025 Ubique Innovation AG <https://www.ubique.ch>
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ *  SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <vector>
+#include <string>
+
+// Helper for loading test data.
+// Files are loaded from the <project-root>/shared/test/data/ directory.
+// This absolute path is determined at build time and is independent of the
+// runtime working directory of the test executable.
+class TestData {
+public:
+    // Returns the absolute path to file at path relative to
+    // <project-root>/shared/test/data directory
+    static std::string resolve(const char *relPath);
+
+    // Read the file at path into a string.
+    // relPath is relative to the <project-root>/shared/test/data/ directory.
+    static std::string readFileToString(const char *relPath);
+    
+    // Read the file at path into a char buffer.
+    // relPath is relative to the <project-root>/shared/test/data/ directory.
+    static std::vector<char> readFileToBuffer(const char *relPath);
+};


### PR DESCRIPTION
Determine the absolute path to the test data directory at build time.
This allows to run the test binary from any working directory.

If necessary, the data directory can be overridden at runtime via the
environment variable OPENMOBILEMAPS_TESTDATA_DIR.

Tangent: in TestGeometryHandler benchmarks, move reading of file data out of measured block.
And, also in TestGeometryHandler, initialize a CoordinateConversionHandler directly with a render system instead of (ab-)using the "independent instance" -- the internal renderSystemConverter is otherwise not properly set.