### PR TITLE
Use vao for the OpenGL object vertex attributes management

### DIFF
--- a/android/src/main/cpp/graphics/objects/IcosahedronOpenGl.h
+++ b/android/src/main/cpp/graphics/objects/IcosahedronOpenGl.h
@@ -56,6 +56,7 @@ protected:
     int mMatrixHandle;
     int positionHandle;
     int valueHandle;
+    GLuint vao;
     GLuint vertexBuffer;
     std::vector<GLfloat> vertices;
     GLuint indexBuffer;

--- a/android/src/main/cpp/graphics/objects/LineGroup2dOpenGl.h
+++ b/android/src/main/cpp/graphics/objects/LineGroup2dOpenGl.h
@@ -66,6 +66,7 @@ protected:
     int vertexIndexHandle;
     int segmentStartLPosHandle;
     int styleInfoHandle;
+    GLuint vao;
     GLuint vertexAttribBuffer = -1;
     std::vector<GLfloat> lineAttributes;
     GLuint indexBuffer = -1;

--- a/android/src/main/cpp/graphics/objects/Polygon2dOpenGl.h
+++ b/android/src/main/cpp/graphics/objects/Polygon2dOpenGl.h
@@ -64,6 +64,7 @@ protected:
     int mMatrixHandle;
     int originOffsetHandle;
     int positionHandle;
+    GLuint vao;
     GLuint vertexBuffer;
     std::vector<GLfloat> vertices;
     GLuint indexBuffer;

--- a/android/src/main/cpp/graphics/objects/PolygonGroup2dOpenGl.h
+++ b/android/src/main/cpp/graphics/objects/PolygonGroup2dOpenGl.h
@@ -62,9 +62,10 @@ protected:
     int scaleFactorHandle;
     int positionHandle;
     int styleIndexHandle;
-    GLuint attribBuffer = -1;
+    GLuint vao;
+    GLuint attribBuffer;
     std::vector<GLfloat> polygonAttributes;
-    GLuint indexBuffer = -1;
+    GLuint indexBuffer;
     std::vector<GLushort> polygonIndices;
     bool glDataBuffersGenerated = false;
     Vec3D polygonOrigin = Vec3D(0.0, 0.0, 0.0);

--- a/android/src/main/cpp/graphics/objects/PolygonPatternGroup2dOpenGl.h
+++ b/android/src/main/cpp/graphics/objects/PolygonPatternGroup2dOpenGl.h
@@ -79,6 +79,7 @@ protected:
     int originOffsetHandle;
     int positionHandle;
     int styleIndexHandle;
+    GLuint vao;
     GLuint vertexBuffer;
     std::vector<GLfloat> vertices;
     GLuint indexBuffer;

--- a/android/src/main/cpp/graphics/objects/Quad2dInstancedOpenGl.h
+++ b/android/src/main/cpp/graphics/objects/Quad2dInstancedOpenGl.h
@@ -93,6 +93,7 @@ protected:
     int originOffsetHandle;
     int originHandle;
     int positionHandle;
+    GLuint vao;
     GLuint vertexBuffer;
     std::vector<GLfloat> vertices;
     int textureCoordinateHandle;
@@ -101,6 +102,7 @@ protected:
     GLuint indexBuffer;
     std::vector<GLubyte> indices;
     bool glDataBuffersGenerated = false;
+    bool texCoordBufferGenerated = false;
     Vec3D quadsOrigin = Vec3D(0.0, 0.0, 0.0);
 
     std::shared_ptr<TextureHolderInterface> textureHolder;

--- a/android/src/main/cpp/graphics/objects/Quad2dOpenGl.h
+++ b/android/src/main/cpp/graphics/objects/Quad2dOpenGl.h
@@ -77,13 +77,16 @@ protected:
     int program;
 
     bool glDataBuffersGenerated = false;
+    bool texCoordBufferGenerated = false;
     int vpMatrixHandle;
     int mMatrixHandle;
     int originOffsetHandle;
     int originHandle;
     int positionHandle;
+    GLuint vao;
     GLuint vertexBuffer;
     std::vector<GLfloat> vertices;
+    int textureUniformHandle;
     int textureCoordinateHandle;
     GLuint textureCoordsBuffer;
     std::vector<GLfloat> textureCoords;

--- a/android/src/main/cpp/graphics/objects/Quad2dStretchedInstancedOpenGl.cpp
+++ b/android/src/main/cpp/graphics/objects/Quad2dStretchedInstancedOpenGl.cpp
@@ -83,27 +83,27 @@ void Quad2dStretchedInstancedOpenGl::setup(const std::shared_ptr<::RenderingCont
 void Quad2dStretchedInstancedOpenGl::prepareGlData(int program) {
     glUseProgram(program);
 
-    positionHandle = glGetAttribLocation(program, "vPosition");
+    if (!glDataBuffersGenerated) {
+        glGenVertexArrays(1, &vao);
+    }
+    glBindVertexArray(vao);
+
     if (!glDataBuffersGenerated) {
         glGenBuffers(1, &vertexBuffer);
     }
     glBindBuffer(GL_ARRAY_BUFFER, vertexBuffer);
     glBufferData(GL_ARRAY_BUFFER, sizeof(GLfloat) * vertices.size(), &vertices[0], GL_STATIC_DRAW);
 
+    positionHandle = glGetAttribLocation(program, "vPosition");
+
+    glEnableVertexAttribArray(positionHandle);
+    glVertexAttribPointer(positionHandle, 3, GL_FLOAT, false, 0, nullptr);
+
     if (!glDataBuffersGenerated) {
         glGenBuffers(1, &dynamicInstanceDataBuffer);
     }
     glBindBuffer(GL_ARRAY_BUFFER, dynamicInstanceDataBuffer);
     glBufferData(GL_ARRAY_BUFFER, instanceCount * (is3d ? instValuesSizeBytes3d : instValuesSizeBytes), nullptr, GL_DYNAMIC_DRAW);
-
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
-
-    if (!glDataBuffersGenerated) {
-        glGenBuffers(1, &indexBuffer);
-    }
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexBuffer);
-    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte) * indices.size(), &indices[0], GL_STATIC_DRAW);
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 
     instPositionsHandle = glGetAttribLocation(program, "aPosition");
     instTextureCoordinatesHandle = glGetAttribLocation(program, "aTexCoordinate");
@@ -114,6 +114,43 @@ void Quad2dStretchedInstancedOpenGl::prepareGlData(int program) {
     instStretchXsHandle = glGetAttribLocation(program, "aStretchX");
     instStretchYsHandle = glGetAttribLocation(program, "aStretchY");
 
+    glVertexAttribPointer(instPositionsHandle, is3d ? 3 : 2, GL_FLOAT, GL_FALSE, 0, (float *)((is3d ? instPositionsOffsetBytes3d : instPositionsOffsetBytes) * instanceCount));
+    glEnableVertexAttribArray(instPositionsHandle);
+    glVertexAttribDivisor(instPositionsHandle, 1);
+    glVertexAttribPointer(instTextureCoordinatesHandle, 4, GL_FLOAT, GL_FALSE, 0, (float *)((is3d ? instTextureCoordinatesOffsetBytes3d : instTextureCoordinatesOffsetBytes) * instanceCount));
+    glEnableVertexAttribArray(instTextureCoordinatesHandle);
+    glVertexAttribDivisor(instTextureCoordinatesHandle, 1);
+    glVertexAttribPointer(instScalesHandle, 2, GL_FLOAT, GL_FALSE, 0, (float *)((is3d ? instScalesOffsetBytes3d : instScalesOffsetBytes) * instanceCount));
+    glEnableVertexAttribArray(instScalesHandle);
+    glVertexAttribDivisor(instScalesHandle, 1);
+    glVertexAttribPointer(instRotationsHandle, 1, GL_FLOAT, GL_FALSE, 0, (float *)((is3d ? instRotationsOffsetBytes3d : instRotationsOffsetBytes) * instanceCount));
+    glEnableVertexAttribArray(instRotationsHandle);
+    glVertexAttribDivisor(instRotationsHandle, 1);
+    glVertexAttribPointer(instAlphasHandle, 1, GL_FLOAT, GL_FALSE, 0, (float *)((is3d ? instAlphasOffsetBytes3d : instAlphasOffsetBytes) * instanceCount));
+    glEnableVertexAttribArray(instAlphasHandle);
+    glVertexAttribDivisor(instAlphasHandle, 1);
+    glVertexAttribPointer(instStretchScalesHandle, 2, GL_FLOAT, GL_FALSE, 10 * sizeof(GLfloat), (float *)((is3d ? instStretchInfoOffsetBytes3d : instStretchInfoOffsetBytes) * instanceCount));
+    glEnableVertexAttribArray(instStretchScalesHandle);
+    glVertexAttribDivisor(instStretchScalesHandle, 1);
+    glVertexAttribPointer(instStretchXsHandle, 4, GL_FLOAT, GL_FALSE, 10 * sizeof(GLfloat), (float *)((is3d ? instStretchInfoOffsetBytes3d : instStretchInfoOffsetBytes) * instanceCount + instStretchXsAddOffsetBytes));
+    glEnableVertexAttribArray(instStretchXsHandle);
+    glVertexAttribDivisor(instStretchXsHandle, 1);
+    glVertexAttribPointer(instStretchYsHandle, 4, GL_FLOAT, GL_FALSE, 10 * sizeof(GLfloat), (float *)((is3d ? instStretchInfoOffsetBytes3d : instStretchInfoOffsetBytes) * instanceCount + instStretchYsAddOffsetBytes));
+    glEnableVertexAttribArray(instStretchYsHandle);
+    glVertexAttribDivisor(instStretchYsHandle, 1);
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+    if (!glDataBuffersGenerated) {
+        glGenBuffers(1, &indexBuffer);
+    }
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexBuffer);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte) * indices.size(), &indices[0], GL_STATIC_DRAW);
+
+    glBindVertexArray(0);
+
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+
     vpMatrixHandle = glGetUniformLocation(program, "uvpMatrix");
     mMatrixHandle = glGetUniformLocation(program, "umMatrix");
     originOffsetHandle = glGetUniformLocation(program, "uOriginOffset");
@@ -123,23 +160,29 @@ void Quad2dStretchedInstancedOpenGl::prepareGlData(int program) {
 
 void Quad2dStretchedInstancedOpenGl::prepareTextureCoordsGlData(int program) {
     glUseProgram(program);
-
-    if (textureCoordsReady) {
-        removeTextureCoordsGlBuffers();
-    }
+    glBindVertexArray(vao);
 
     textureCoordinateHandle = glGetAttribLocation(program, "texCoordinate");
     if (textureCoordinateHandle < 0) {
         usesTextureCoords = false;
         return;
     }
-    glGenBuffers(1, &textureCoordsBuffer);
+
+    if (!texCoordBufferGenerated) {
+        glGenBuffers(1, &textureCoordsBuffer);
+    }
+
     glBindBuffer(GL_ARRAY_BUFFER, textureCoordsBuffer);
     glBufferData(GL_ARRAY_BUFFER, sizeof(GLfloat) * textureCoords.size(), &textureCoords[0], GL_STATIC_DRAW);
+
+    glEnableVertexAttribArray(textureCoordinateHandle);
+    glVertexAttribPointer(textureCoordinateHandle, 2, GL_FLOAT, false, 0, nullptr);
 
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     usesTextureCoords = true;
     textureCoordsReady = true;
+
+    glBindVertexArray(0);
 }
 
 void Quad2dStretchedInstancedOpenGl::removeGlBuffers() {
@@ -147,13 +190,17 @@ void Quad2dStretchedInstancedOpenGl::removeGlBuffers() {
         glDeleteBuffers(1, &vertexBuffer);
         glDeleteBuffers(1, &indexBuffer);
         glDeleteBuffers(1, &dynamicInstanceDataBuffer);
+        glDeleteVertexArrays(1, &vao);
         glDataBuffersGenerated = false;
     }
 }
 
 void Quad2dStretchedInstancedOpenGl::removeTextureCoordsGlBuffers() {
     if (textureCoordsReady) {
-        glDeleteBuffers(1, &textureCoordsBuffer);
+        if (texCoordBufferGenerated) {
+            glDeleteBuffers(1, &textureCoordsBuffer);
+            texCoordBufferGenerated = false;
+        }
         textureCoordsReady = false;
     }
 }
@@ -213,8 +260,6 @@ void Quad2dStretchedInstancedOpenGl::render(const std::shared_ptr<::RenderingCon
         return;
     }
 
-    glUseProgram(program);
-
     GLuint stencilMask = 0;
     GLuint validTarget = 0;
     GLenum zpass = GL_KEEP;
@@ -232,51 +277,16 @@ void Quad2dStretchedInstancedOpenGl::render(const std::shared_ptr<::RenderingCon
         glStencilOp(GL_KEEP, GL_KEEP, zpass);
     }
 
+    glUseProgram(program);
+    glBindVertexArray(vao);
+
     if (usesTextureCoords) {
         prepareTextureDraw(program);
-
-        glEnableVertexAttribArray(textureCoordinateHandle);
-        glBindBuffer(GL_ARRAY_BUFFER, textureCoordsBuffer);
-        glVertexAttribPointer(textureCoordinateHandle, 2, GL_FLOAT, false, 0, nullptr);
-
         auto textureFactorHandle = glGetUniformLocation(program, "textureFactor");
         glUniform2f(textureFactorHandle, factorWidth, factorHeight);
     }
 
-    glBindBuffer(GL_ARRAY_BUFFER, dynamicInstanceDataBuffer);
-    glVertexAttribPointer(instPositionsHandle, is3d ? 3 : 2, GL_FLOAT, GL_FALSE, 0, (float *)((is3d ? instPositionsOffsetBytes3d : instPositionsOffsetBytes) * instanceCount));
-    glEnableVertexAttribArray(instPositionsHandle);
-    glVertexAttribDivisor(instPositionsHandle, 1);
-    glVertexAttribPointer(instTextureCoordinatesHandle, 4, GL_FLOAT, GL_FALSE, 0, (float *)((is3d ? instTextureCoordinatesOffsetBytes3d : instTextureCoordinatesOffsetBytes) * instanceCount));
-    glEnableVertexAttribArray(instTextureCoordinatesHandle);
-    glVertexAttribDivisor(instTextureCoordinatesHandle, 1);
-    glVertexAttribPointer(instScalesHandle, 2, GL_FLOAT, GL_FALSE, 0, (float *)((is3d ? instScalesOffsetBytes3d : instScalesOffsetBytes) * instanceCount));
-    glEnableVertexAttribArray(instScalesHandle);
-    glVertexAttribDivisor(instScalesHandle, 1);
-    glVertexAttribPointer(instRotationsHandle, 1, GL_FLOAT, GL_FALSE, 0, (float *)((is3d ? instRotationsOffsetBytes3d : instRotationsOffsetBytes) * instanceCount));
-    glEnableVertexAttribArray(instRotationsHandle);
-    glVertexAttribDivisor(instRotationsHandle, 1);
-    glVertexAttribPointer(instAlphasHandle, 1, GL_FLOAT, GL_FALSE, 0, (float *)((is3d ? instAlphasOffsetBytes3d : instAlphasOffsetBytes) * instanceCount));
-    glEnableVertexAttribArray(instAlphasHandle);
-    glVertexAttribDivisor(instAlphasHandle, 1);
-    glVertexAttribPointer(instStretchScalesHandle, 2, GL_FLOAT, GL_FALSE, 10 * sizeof(GLfloat), (float *)((is3d ? instStretchInfoOffsetBytes3d : instStretchInfoOffsetBytes) * instanceCount));
-    glEnableVertexAttribArray(instStretchScalesHandle);
-    glVertexAttribDivisor(instStretchScalesHandle, 1);
-    glVertexAttribPointer(instStretchXsHandle, 4, GL_FLOAT, GL_FALSE, 10 * sizeof(GLfloat), (float *)((is3d ? instStretchInfoOffsetBytes3d : instStretchInfoOffsetBytes) * instanceCount + instStretchXsAddOffsetBytes));
-    glEnableVertexAttribArray(instStretchXsHandle);
-    glVertexAttribDivisor(instStretchXsHandle, 1);
-    glVertexAttribPointer(instStretchYsHandle, 4, GL_FLOAT, GL_FALSE, 10 * sizeof(GLfloat), (float *)((is3d ? instStretchInfoOffsetBytes3d : instStretchInfoOffsetBytes) * instanceCount + instStretchYsAddOffsetBytes));
-    glEnableVertexAttribArray(instStretchYsHandle);
-    glVertexAttribDivisor(instStretchYsHandle, 1);
-
     shaderProgram->preRender(context);
-
-    // enable vPosition attribs
-    glEnableVertexAttribArray(positionHandle);
-    glBindBuffer(GL_ARRAY_BUFFER, vertexBuffer);
-    glVertexAttribPointer(positionHandle, 3, GL_FLOAT, false, 0, nullptr);
-
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
 
     // Apply the projection and view transformation
     glUniformMatrix4fv(vpMatrixHandle, 1, false, (GLfloat *)vpMatrix);
@@ -285,34 +295,9 @@ void Quad2dStretchedInstancedOpenGl::render(const std::shared_ptr<::RenderingCon
     glUniform4f(originOffsetHandle, quadsOrigin.x - origin.x, quadsOrigin.y - origin.y, quadsOrigin.z - origin.z, 0.0);
 
     // Draw the triangles
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexBuffer);
     glDrawElementsInstanced(GL_TRIANGLES,6, GL_UNSIGNED_BYTE, nullptr, instanceCount);
 
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
-
-    glVertexAttribDivisor(instPositionsHandle, 0);
-    glVertexAttribDivisor(instTextureCoordinatesHandle, 0);
-    glVertexAttribDivisor(instScalesHandle, 0);
-    glVertexAttribDivisor(instRotationsHandle, 0);
-    glVertexAttribDivisor(instAlphasHandle, 0);
-    glVertexAttribDivisor(instStretchScalesHandle, 0);
-    glVertexAttribDivisor(instStretchXsHandle, 0);
-    glVertexAttribDivisor(instStretchYsHandle, 0);
-
-    // Disable vertex array
-    glDisableVertexAttribArray(positionHandle);
-    if (textureHolder) {
-        glDisableVertexAttribArray(textureCoordinateHandle);
-    }
-    glDisableVertexAttribArray(instPositionsHandle);
-    glDisableVertexAttribArray(instTextureCoordinatesHandle);
-    glDisableVertexAttribArray(instScalesHandle);
-    glDisableVertexAttribArray(instRotationsHandle);
-    glDisableVertexAttribArray(instAlphasHandle);
-    glDisableVertexAttribArray(instStretchScalesHandle);
-    glDisableVertexAttribArray(instStretchXsHandle);
-    glDisableVertexAttribArray(instStretchYsHandle);
-
+    glBindVertexArray(0);
 
     glDisable(GL_BLEND);
 

--- a/android/src/main/cpp/graphics/objects/Quad2dStretchedInstancedOpenGl.h
+++ b/android/src/main/cpp/graphics/objects/Quad2dStretchedInstancedOpenGl.h
@@ -92,6 +92,7 @@ class Quad2dStretchedInstancedOpenGl : public GraphicsObjectInterface,
     int mMatrixHandle;
     int originOffsetHandle;
     int positionHandle;
+    GLuint vao;
     GLuint vertexBuffer;
     std::vector<GLfloat> vertices;
     int textureCoordinateHandle;
@@ -100,6 +101,7 @@ class Quad2dStretchedInstancedOpenGl : public GraphicsObjectInterface,
     GLuint indexBuffer;
     std::vector<GLubyte> indices;
     bool glDataBuffersGenerated = false;
+    bool texCoordBufferGenerated = false;
     Vec3D quadsOrigin = Vec3D(0.0, 0.0, 0.0);
 
     std::shared_ptr<TextureHolderInterface> textureHolder;

--- a/android/src/main/cpp/graphics/objects/Text2dInstancedOpenGl.h
+++ b/android/src/main/cpp/graphics/objects/Text2dInstancedOpenGl.h
@@ -88,6 +88,7 @@ protected:
     int originOffsetHandle;
     int originHandle;
     int positionHandle;
+    GLuint vao;
     GLuint vertexBuffer;
     std::vector<GLfloat> vertices;
     int textureCoordinateHandle;
@@ -96,6 +97,7 @@ protected:
     GLuint indexBuffer;
     std::vector<GLubyte> indices;
     bool glDataBuffersGenerated = false;
+    bool texCoordBufferGenerated = false;
     Vec3D quadsOrigin = Vec3D(0.0, 0.0, 0.0);
 
     std::shared_ptr<TextureHolderInterface> textureHolder;

--- a/android/src/main/cpp/graphics/objects/Text2dOpenGl.h
+++ b/android/src/main/cpp/graphics/objects/Text2dOpenGl.h
@@ -71,9 +71,10 @@ protected:
     int mMatrixHandle = -1;
     int positionHandle = -1;
     int textureCoordinateHandle = -1;
-    GLuint vertexAttribBuffer = -1;
+    GLuint vao;
+    GLuint vertexAttribBuffer;
     std::vector<GLfloat> textVertexAttributes;
-    GLuint indexBuffer = -1;
+    GLuint indexBuffer;
     std::vector<GLushort> textIndices;
     bool glDataBuffersGenerated = false;
 


### PR DESCRIPTION
Significantly reduces the gl calls per frame.