### PR TITLE
Use correct coordinate system identifier for line click

### DIFF
--- a/shared/src/map/layers/tiled/vector/tiles/line/Tiled2dMapVectorLineTile.cpp
+++ b/shared/src/map/layers/tiled/vector/tiles/line/Tiled2dMapVectorLineTile.cpp
@@ -546,7 +546,7 @@ bool Tiled2dMapVectorLineTile::performClick(const Coord &coord) {
             auto lineWidth = lineDescription->style.getLineWidth(EvaluationContext(zoomIdentifier, dpFactor, featureContext, featureStateManager));
             lineWidth *= selectionSizeFactor;
             auto lineWidthInMapUnits = camera->mapUnitsFromPixels(lineWidth);
-            if (LineHelper::pointWithin(coordinates, Coord(CoordinateSystemIdentifiers::EPSG3857(), coord.x, coord.y, 0.0), CoordinateSystemIdentifiers::EPSG3857(), lineWidthInMapUnits, coordinateConverter)) {
+            if (LineHelper::pointWithin(coordinates, coord, CoordinateSystemIdentifiers::EPSG3857(), lineWidthInMapUnits, coordinateConverter)) {
                 if (multiselect) {
                     featureInfos.push_back(featureContext->getFeatureInfo());
                 } else if (strongSelectionDelegate->didSelectFeature(featureContext->getFeatureInfo(), description->identifier, coord)) {


### PR DESCRIPTION
PerformClick coordinate argument is in mapCoordinateSystem and not always EPSG3857. The conversion to render coordinates then is most of the time garbage and not correctly comparable to the correctly converted render coordinates.