### PR TITLE
GlShaders Renderability

### DIFF
--- a/android/src/main/cpp/graphics/objects/GraphicsObjectFactoryOpenGl.cpp
+++ b/android/src/main/cpp/graphics/objects/GraphicsObjectFactoryOpenGl.cpp
@@ -20,7 +20,6 @@
 #include "Text2dInstancedOpenGl.h"
 #include "Quad2dStretchedInstancedOpenGl.h"
 #include "IcosahedronOpenGl.h"
-#include <cassert>
 
 std::shared_ptr<Quad2dInterface> GraphicsObjectFactoryOpenGl::createQuad(const std::shared_ptr<::ShaderProgramInterface> &shader) {
     return std::make_shared<Quad2dOpenGl>(enforceGlShader(shader));
@@ -79,7 +78,7 @@ GraphicsObjectFactoryOpenGl::createIcosahedronObject(const std::shared_ptr<::Sha
 }
 
 std::shared_ptr<BaseShaderProgramOpenGl> GraphicsObjectFactoryOpenGl::enforceGlShader(const std::shared_ptr<::ShaderProgramInterface> &shader) {
-    std::shared_ptr<BaseShaderProgramOpenGl> glShader = std::static_pointer_cast<BaseShaderProgramOpenGl>(shader);
+    std::shared_ptr<BaseShaderProgramOpenGl> glShader = std::dynamic_pointer_cast<BaseShaderProgramOpenGl>(shader);
     if (!glShader) {
         throw std::runtime_error("GraphicsObjectFactoryOpenGl: ShaderProgramInterface doesn't extend BaseShaderProgramOpenGl!");
     }

--- a/android/src/main/cpp/graphics/objects/GraphicsObjectFactoryOpenGl.cpp
+++ b/android/src/main/cpp/graphics/objects/GraphicsObjectFactoryOpenGl.cpp
@@ -20,29 +20,30 @@
 #include "Text2dInstancedOpenGl.h"
 #include "Quad2dStretchedInstancedOpenGl.h"
 #include "IcosahedronOpenGl.h"
+#include <cassert>
 
 std::shared_ptr<Quad2dInterface> GraphicsObjectFactoryOpenGl::createQuad(const std::shared_ptr<::ShaderProgramInterface> &shader) {
-    return std::make_shared<Quad2dOpenGl>(shader);
+    return std::make_shared<Quad2dOpenGl>(enforceGlShader(shader));
 }
 
 std::shared_ptr<Polygon2dInterface>
 GraphicsObjectFactoryOpenGl::createPolygon(const std::shared_ptr<::ShaderProgramInterface> &shader) {
-    return std::make_shared<Polygon2dOpenGl>(shader);
+    return std::make_shared<Polygon2dOpenGl>(enforceGlShader(shader));
 }
 
 std::shared_ptr<LineGroup2dInterface>
 GraphicsObjectFactoryOpenGl::createLineGroup(const std::shared_ptr<::ShaderProgramInterface> &shader) {
-    return std::make_shared<LineGroup2dOpenGl>(shader);
+    return std::make_shared<LineGroup2dOpenGl>(enforceGlShader(shader));
 }
 
 std::shared_ptr<PolygonGroup2dInterface>
 GraphicsObjectFactoryOpenGl::createPolygonGroup(const std::shared_ptr<::ShaderProgramInterface> &shader) {
-    return std::make_shared<PolygonGroup2dOpenGl>(shader);
+    return std::make_shared<PolygonGroup2dOpenGl>(enforceGlShader(shader));
 }
 
 std::shared_ptr<PolygonPatternGroup2dInterface>
 GraphicsObjectFactoryOpenGl::createPolygonPatternGroup(const std::shared_ptr<::ShaderProgramInterface> &shader) {
-    return std::make_shared<PolygonPatternGroup2dOpenGl>(shader);
+    return std::make_shared<PolygonPatternGroup2dOpenGl>(enforceGlShader(shader));
 }
 
 std::shared_ptr<Quad2dInterface> GraphicsObjectFactoryOpenGl::createQuadMask(bool is3D) {
@@ -52,27 +53,35 @@ std::shared_ptr<Quad2dInterface> GraphicsObjectFactoryOpenGl::createQuadMask(boo
 std::shared_ptr<Polygon2dInterface> GraphicsObjectFactoryOpenGl::createPolygonMask(bool is3D) {
     std::shared_ptr<ColorShaderOpenGl> shader = std::make_shared<ColorShaderOpenGl>(is3D);
     shader->setColor(1, 1, 1, 1);
-    return std::make_shared<Polygon2dOpenGl>(shader);
+    return std::make_shared<Polygon2dOpenGl>(enforceGlShader(shader));
 }
 
 std::shared_ptr<TextInterface> GraphicsObjectFactoryOpenGl::createText(const std::shared_ptr<::ShaderProgramInterface> &shader) {
-    return std::make_shared<Text2dOpenGl>(shader);
+    return std::make_shared<Text2dOpenGl>(enforceGlShader(shader));
 }
 
 std::shared_ptr<TextInstancedInterface> GraphicsObjectFactoryOpenGl::createTextInstanced(const std::shared_ptr<::ShaderProgramInterface> & shader) {
-    return std::make_shared<Text2dInstancedOpenGl>(shader);
+    return std::make_shared<Text2dInstancedOpenGl>(enforceGlShader(shader));
 }
 
 std::shared_ptr<Quad2dInstancedInterface> GraphicsObjectFactoryOpenGl::createQuadInstanced(const std::shared_ptr<::ShaderProgramInterface> &shader) {
-    return std::make_shared<Quad2dInstancedOpenGl>(shader);
+    return std::make_shared<Quad2dInstancedOpenGl>(enforceGlShader(shader));
 }
 
 std::shared_ptr<Quad2dStretchedInstancedInterface>
 GraphicsObjectFactoryOpenGl::createQuadStretchedInstanced(const std::shared_ptr<::ShaderProgramInterface> &shader) {
-    return std::make_shared<Quad2dStretchedInstancedOpenGl>(shader);
+    return std::make_shared<Quad2dStretchedInstancedOpenGl>(enforceGlShader(shader));
 }
 
 std::shared_ptr<IcosahedronInterface>
 GraphicsObjectFactoryOpenGl::createIcosahedronObject(const std::shared_ptr<::ShaderProgramInterface> &shader) {
-    return std::make_shared<IcosahedronOpenGl>(shader);
+    return std::make_shared<IcosahedronOpenGl>(enforceGlShader(shader));
+}
+
+std::shared_ptr<BaseShaderProgramOpenGl> GraphicsObjectFactoryOpenGl::enforceGlShader(const std::shared_ptr<::ShaderProgramInterface> &shader) {
+    std::shared_ptr<BaseShaderProgramOpenGl> glShader = std::static_pointer_cast<BaseShaderProgramOpenGl>(shader);
+    if (!glShader) {
+        throw std::runtime_error("GraphicsObjectFactoryOpenGl: ShaderProgramInterface doesn't extend BaseShaderProgramOpenGl!");
+    }
+    return glShader;
 }

--- a/android/src/main/cpp/graphics/objects/GraphicsObjectFactoryOpenGl.h
+++ b/android/src/main/cpp/graphics/objects/GraphicsObjectFactoryOpenGl.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "GraphicsObjectFactoryInterface.h"
+#include "BaseShaderProgramOpenGl.h"
 
 class GraphicsObjectFactoryOpenGl : public GraphicsObjectFactoryInterface {
 public:
@@ -37,4 +38,7 @@ public:
     std::shared_ptr<Quad2dStretchedInstancedInterface> createQuadStretchedInstanced(const std::shared_ptr<::ShaderProgramInterface> &shader) override;
 
     std::shared_ptr<IcosahedronInterface> createIcosahedronObject(const std::shared_ptr<::ShaderProgramInterface> &shader) override;
+
+private:
+    static std::shared_ptr<BaseShaderProgramOpenGl> enforceGlShader(const std::shared_ptr<::ShaderProgramInterface> &shader);
 };

--- a/android/src/main/cpp/graphics/objects/IcosahedronOpenGl.cpp
+++ b/android/src/main/cpp/graphics/objects/IcosahedronOpenGl.cpp
@@ -11,7 +11,7 @@
 #include "IcosahedronOpenGl.h"
 #include <cstring>
 
-IcosahedronOpenGl::IcosahedronOpenGl(const std::shared_ptr<::ShaderProgramInterface> &shader)
+IcosahedronOpenGl::IcosahedronOpenGl(const std::shared_ptr<::BaseShaderProgramOpenGl> &shader)
     : shaderProgram(shader) {}
 
 std::shared_ptr<GraphicsObjectInterface> IcosahedronOpenGl::asGraphicsObject() { return shared_from_this(); }

--- a/android/src/main/cpp/graphics/objects/IcosahedronOpenGl.h
+++ b/android/src/main/cpp/graphics/objects/IcosahedronOpenGl.h
@@ -16,13 +16,14 @@
 #include "IcosahedronInterface.h"
 #include "ShaderProgramInterface.h"
 #include "opengl_wrapper.h"
+#include "BaseShaderProgramOpenGl.h"
 #include <mutex>
 
 class IcosahedronOpenGl : public GraphicsObjectInterface,
                           public IcosahedronInterface,
                           public std::enable_shared_from_this<IcosahedronOpenGl> {
 public:
-    IcosahedronOpenGl(const std::shared_ptr<::ShaderProgramInterface> &shader);
+    IcosahedronOpenGl(const std::shared_ptr<::BaseShaderProgramOpenGl> &shader);
 
     ~IcosahedronOpenGl(){};
 
@@ -48,7 +49,7 @@ protected:
 
     void removeGlBuffers();
 
-    std::shared_ptr<ShaderProgramInterface> shaderProgram;
+    std::shared_ptr<BaseShaderProgramOpenGl> shaderProgram;
     std::string programName;
     int program = 0;
 

--- a/android/src/main/cpp/graphics/objects/LineGroup2dOpenGl.h
+++ b/android/src/main/cpp/graphics/objects/LineGroup2dOpenGl.h
@@ -16,6 +16,7 @@
 #include "OpenGlHelper.h"
 #include "RenderLineDescription.h"
 #include "ShaderProgramInterface.h"
+#include "BaseShaderProgramOpenGl.h"
 #include "opengl_wrapper.h"
 #include <mutex>
 
@@ -23,7 +24,7 @@ class LineGroup2dOpenGl : public GraphicsObjectInterface,
                           public LineGroup2dInterface,
                           public std::enable_shared_from_this<GraphicsObjectInterface> {
   public:
-    LineGroup2dOpenGl(const std::shared_ptr<::ShaderProgramInterface> &shader);
+    LineGroup2dOpenGl(const std::shared_ptr<BaseShaderProgramOpenGl> &shader);
 
     virtual ~LineGroup2dOpenGl() {}
 
@@ -52,7 +53,7 @@ protected:
     virtual void removeGlBuffers();
 
     bool is3d = false;
-    std::shared_ptr<ShaderProgramInterface> shaderProgram;
+    std::shared_ptr<BaseShaderProgramOpenGl> shaderProgram;
     std::string programName;
     int program = 0;
 

--- a/android/src/main/cpp/graphics/objects/Polygon2dOpenGl.cpp
+++ b/android/src/main/cpp/graphics/objects/Polygon2dOpenGl.cpp
@@ -12,7 +12,7 @@
 #include "OpenGlHelper.h"
 #include <cstring>
 
-Polygon2dOpenGl::Polygon2dOpenGl(const std::shared_ptr<::ShaderProgramInterface> &shader)
+Polygon2dOpenGl::Polygon2dOpenGl(const std::shared_ptr<::BaseShaderProgramOpenGl> &shader)
     : shaderProgram(shader) {}
 
 std::shared_ptr<GraphicsObjectInterface> Polygon2dOpenGl::asGraphicsObject() { return shared_from_this(); }
@@ -118,7 +118,8 @@ void Polygon2dOpenGl::setIsInverseMasked(bool inversed) { isMaskInversed = inver
 void Polygon2dOpenGl::render(const std::shared_ptr<::RenderingContextInterface> &context, const RenderPassConfig &renderPass,
                              int64_t vpMatrix, int64_t mMatrix, const ::Vec3D &origin, bool isMasked,
                              double screenPixelAsRealMeterFactor) {
-    if (!ready)
+    std::lock_guard<std::recursive_mutex> lock(dataMutex);
+    if (!ready || !shaderProgram->isRenderable())
         return;
 
     std::shared_ptr<OpenGlContext> openGlContext = std::static_pointer_cast<OpenGlContext>(context);

--- a/android/src/main/cpp/graphics/objects/Polygon2dOpenGl.h
+++ b/android/src/main/cpp/graphics/objects/Polygon2dOpenGl.h
@@ -15,6 +15,7 @@
 #include "OpenGlContext.h"
 #include "Polygon2dInterface.h"
 #include "ShaderProgramInterface.h"
+#include "BaseShaderProgramOpenGl.h"
 #include "opengl_wrapper.h"
 #include <mutex>
 
@@ -23,7 +24,7 @@ class Polygon2dOpenGl : public GraphicsObjectInterface,
                         public Polygon2dInterface,
                         public std::enable_shared_from_this<Polygon2dOpenGl> {
   public:
-    Polygon2dOpenGl(const std::shared_ptr<::ShaderProgramInterface> &shader);
+    Polygon2dOpenGl(const std::shared_ptr<::BaseShaderProgramOpenGl> &shader);
 
     ~Polygon2dOpenGl(){};
 
@@ -56,7 +57,7 @@ protected:
 
     inline void drawPolygon(const std::shared_ptr<::RenderingContextInterface> &context, int program, int64_t vpMatrix, int64_t mMatrix, const Vec3D &origin);
 
-    std::shared_ptr<ShaderProgramInterface> shaderProgram;
+    std::shared_ptr<BaseShaderProgramOpenGl> shaderProgram;
     std::string programName;
     int program = 0;
 

--- a/android/src/main/cpp/graphics/objects/PolygonGroup2dOpenGl.cpp
+++ b/android/src/main/cpp/graphics/objects/PolygonGroup2dOpenGl.cpp
@@ -10,11 +10,10 @@
 
 #include "PolygonGroup2dOpenGl.h"
 #include "RenderVerticesDescription.h"
-#include "BaseShaderProgramOpenGl.h"
 #include <cmath>
 #include <cstring>
 
-PolygonGroup2dOpenGl::PolygonGroup2dOpenGl(const std::shared_ptr<::ShaderProgramInterface> &shader)
+PolygonGroup2dOpenGl::PolygonGroup2dOpenGl(const std::shared_ptr<::BaseShaderProgramOpenGl> &shader)
     : shaderProgram(shader) {}
 
 std::shared_ptr<GraphicsObjectInterface> PolygonGroup2dOpenGl::asGraphicsObject() { return shared_from_this(); }
@@ -128,7 +127,8 @@ void PolygonGroup2dOpenGl::setIsInverseMasked(bool inversed) { isMaskInversed = 
 void PolygonGroup2dOpenGl::render(const std::shared_ptr<::RenderingContextInterface> &context, const RenderPassConfig &renderPass,
                                   int64_t vpMatrix, int64_t mMatrix, const ::Vec3D &origin,
                                   bool isMasked, double screenPixelAsRealMeterFactor) {
-    if (!ready)
+    std::lock_guard<std::recursive_mutex> lock(dataMutex);
+    if (!ready || !shaderProgram->isRenderable())
         return;
 
     GLuint stencilMask = 0;

--- a/android/src/main/cpp/graphics/objects/PolygonGroup2dOpenGl.h
+++ b/android/src/main/cpp/graphics/objects/PolygonGroup2dOpenGl.h
@@ -16,6 +16,7 @@
 #include "PolygonGroup2dInterface.h"
 #include "RenderLineDescription.h"
 #include "ShaderProgramInterface.h"
+#include "BaseShaderProgramOpenGl.h"
 #include "opengl_wrapper.h"
 #include <mutex>
 
@@ -23,7 +24,7 @@ class PolygonGroup2dOpenGl : public GraphicsObjectInterface,
                              public PolygonGroup2dInterface,
                              public std::enable_shared_from_this<GraphicsObjectInterface> {
   public:
-    PolygonGroup2dOpenGl(const std::shared_ptr<::ShaderProgramInterface> &shader);
+    PolygonGroup2dOpenGl(const std::shared_ptr<::BaseShaderProgramOpenGl> &shader);
 
     virtual ~PolygonGroup2dOpenGl() {}
 
@@ -52,7 +53,7 @@ protected:
 
     virtual void removeGlBuffers();
 
-    std::shared_ptr<ShaderProgramInterface> shaderProgram;
+    std::shared_ptr<BaseShaderProgramOpenGl> shaderProgram;
     std::string programName;
     int program = 0;
 

--- a/android/src/main/cpp/graphics/objects/PolygonPatternGroup2dOpenGl.cpp
+++ b/android/src/main/cpp/graphics/objects/PolygonPatternGroup2dOpenGl.cpp
@@ -12,10 +12,9 @@
 #include "Logger.h"
 #include "OpenGlHelper.h"
 #include "TextureHolderInterface.h"
-#include "BaseShaderProgramOpenGl.h"
 #include <cstring>
 
-PolygonPatternGroup2dOpenGl::PolygonPatternGroup2dOpenGl(const std::shared_ptr<::ShaderProgramInterface> &shader)
+PolygonPatternGroup2dOpenGl::PolygonPatternGroup2dOpenGl(const std::shared_ptr<::BaseShaderProgramOpenGl> &shader)
     : shaderProgram(shader) {}
 
 bool PolygonPatternGroup2dOpenGl::isReady() { return ready && textureHolder && !buffersNotReady; }
@@ -160,7 +159,7 @@ PolygonPatternGroup2dOpenGl::render(const std::shared_ptr<::RenderingContextInte
                                     int64_t vpMatrix, int64_t mMatrix, const ::Vec3D &origin,
                                     bool isMasked, double screenPixelAsRealMeterFactor) {
     std::lock_guard<std::recursive_mutex> lock(dataMutex);
-    if (!ready || buffersNotReady || !textureHolder) {
+    if (!ready || buffersNotReady || !textureHolder || !shaderProgram->isRenderable()) {
         return;
     }
 

--- a/android/src/main/cpp/graphics/objects/PolygonPatternGroup2dOpenGl.h
+++ b/android/src/main/cpp/graphics/objects/PolygonPatternGroup2dOpenGl.h
@@ -15,6 +15,7 @@
 #include "OpenGlContext.h"
 #include "PolygonPatternGroup2dInterface.h"
 #include "ShaderProgramInterface.h"
+#include "BaseShaderProgramOpenGl.h"
 #include "opengl_wrapper.h"
 #include <mutex>
 #include <vector>
@@ -26,7 +27,7 @@ class PolygonPatternGroup2dOpenGl : public GraphicsObjectInterface,
                      public PolygonPatternGroup2dInterface,
                      public std::enable_shared_from_this<PolygonPatternGroup2dOpenGl> {
   public:
-    PolygonPatternGroup2dOpenGl(const std::shared_ptr<::ShaderProgramInterface> &shader);
+    PolygonPatternGroup2dOpenGl(const std::shared_ptr<::BaseShaderProgramOpenGl> &shader);
 
     ~PolygonPatternGroup2dOpenGl(){};
 
@@ -70,7 +71,7 @@ protected:
 
     void removeGlBuffers();
 
-    std::shared_ptr<ShaderProgramInterface> shaderProgram;
+    std::shared_ptr<BaseShaderProgramOpenGl> shaderProgram;
     std::string programName;
     int program;
 

--- a/android/src/main/cpp/graphics/objects/Quad2dInstancedOpenGl.cpp
+++ b/android/src/main/cpp/graphics/objects/Quad2dInstancedOpenGl.cpp
@@ -12,9 +12,8 @@
 #include "Logger.h"
 #include "OpenGlHelper.h"
 #include "TextureHolderInterface.h"
-#include "BaseShaderProgramOpenGl.h"
 
-Quad2dInstancedOpenGl::Quad2dInstancedOpenGl(const std::shared_ptr<::ShaderProgramInterface> &shader)
+Quad2dInstancedOpenGl::Quad2dInstancedOpenGl(const std::shared_ptr<::BaseShaderProgramOpenGl> &shader)
     : shaderProgram(shader) {}
 
 bool Quad2dInstancedOpenGl::isReady() { return ready && (!usesTextureCoords || textureHolder) && !buffersNotReady; }
@@ -260,7 +259,7 @@ void Quad2dInstancedOpenGl::render(const std::shared_ptr<::RenderingContextInter
                                    int64_t vpMatrix, int64_t mMatrix, const ::Vec3D &origin,
                                    bool isMasked, double screenPixelAsRealMeterFactor) {
     std::lock_guard<std::recursive_mutex> lock(dataMutex);
-    if (!ready || (usesTextureCoords && !textureCoordsReady) || instanceCount == 0 || buffersNotReady) {
+    if (!ready || (usesTextureCoords && !textureCoordsReady) || instanceCount == 0 || buffersNotReady || !shaderProgram->isRenderable()) {
         return;
     }
 

--- a/android/src/main/cpp/graphics/objects/Quad2dInstancedOpenGl.h
+++ b/android/src/main/cpp/graphics/objects/Quad2dInstancedOpenGl.h
@@ -15,6 +15,7 @@
 #include "OpenGlContext.h"
 #include "Quad2dInstancedInterface.h"
 #include "ShaderProgramInterface.h"
+#include "BaseShaderProgramOpenGl.h"
 #include "opengl_wrapper.h"
 #include <mutex>
 #include <vector>
@@ -25,7 +26,7 @@ class Quad2dInstancedOpenGl : public GraphicsObjectInterface,
                      public Quad2dInstancedInterface,
                      public std::enable_shared_from_this<Quad2dInstancedOpenGl> {
   public:
-    Quad2dInstancedOpenGl(const std::shared_ptr<::ShaderProgramInterface> &shader);
+    Quad2dInstancedOpenGl(const std::shared_ptr<::BaseShaderProgramOpenGl> &shader);
 
     ~Quad2dInstancedOpenGl(){};
 
@@ -84,7 +85,7 @@ protected:
     void removeTextureCoordsGlBuffers();
 
     bool is3d = false;
-    std::shared_ptr<ShaderProgramInterface> shaderProgram;
+    std::shared_ptr<BaseShaderProgramOpenGl> shaderProgram;
     std::string programName;
     int program;
 

--- a/android/src/main/cpp/graphics/objects/Quad2dOpenGl.cpp
+++ b/android/src/main/cpp/graphics/objects/Quad2dOpenGl.cpp
@@ -13,7 +13,7 @@
 #include "TextureFilterType.h"
 #include <cmath>
 
-Quad2dOpenGl::Quad2dOpenGl(const std::shared_ptr<::ShaderProgramInterface> &shader)
+Quad2dOpenGl::Quad2dOpenGl(const std::shared_ptr<::BaseShaderProgramOpenGl> &shader)
     : shaderProgram(shader) {}
 
 bool Quad2dOpenGl::isReady() { return ready && (!usesTextureCoords || textureHolder); }
@@ -327,7 +327,7 @@ void Quad2dOpenGl::render(const std::shared_ptr<::RenderingContextInterface> &co
                           int64_t vpMatrix, int64_t mMatrix, const ::Vec3D &origin, bool isMasked,
                           double screenPixelAsRealMeterFactor) {
     std::lock_guard<std::recursive_mutex> lock(dataMutex);
-    if (!ready || (usesTextureCoords && !textureCoordsReady))
+    if (!ready || (usesTextureCoords && !textureCoordsReady) || !shaderProgram->isRenderable())
         return;
 
     GLuint stencilMask = 0;

--- a/android/src/main/cpp/graphics/objects/Quad2dOpenGl.h
+++ b/android/src/main/cpp/graphics/objects/Quad2dOpenGl.h
@@ -15,6 +15,7 @@
 #include "OpenGlContext.h"
 #include "Quad2dInterface.h"
 #include "ShaderProgramInterface.h"
+#include "BaseShaderProgramOpenGl.h"
 #include "opengl_wrapper.h"
 #include <mutex>
 #include <vector>
@@ -24,7 +25,7 @@ class Quad2dOpenGl : public GraphicsObjectInterface,
                      public Quad2dInterface,
                      public std::enable_shared_from_this<Quad2dOpenGl> {
   public:
-    Quad2dOpenGl(const std::shared_ptr<::ShaderProgramInterface> &shader);
+    Quad2dOpenGl(const std::shared_ptr<::BaseShaderProgramOpenGl> &shader);
 
     ~Quad2dOpenGl(){};
 
@@ -72,7 +73,7 @@ protected:
 
     virtual void prepareTextureDraw(int mProgram);
 
-    std::shared_ptr<ShaderProgramInterface> shaderProgram;
+    std::shared_ptr<BaseShaderProgramOpenGl> shaderProgram;
     std::string programName;
     int program;
 

--- a/android/src/main/cpp/graphics/objects/Quad2dStretchedInstancedOpenGl.cpp
+++ b/android/src/main/cpp/graphics/objects/Quad2dStretchedInstancedOpenGl.cpp
@@ -12,10 +12,9 @@
 #include "Logger.h"
 #include "OpenGlHelper.h"
 #include "TextureHolderInterface.h"
-#include "BaseShaderProgramOpenGl.h"
 #include "SharedBytes.h"
 
-Quad2dStretchedInstancedOpenGl::Quad2dStretchedInstancedOpenGl(const std::shared_ptr<::ShaderProgramInterface> &shader)
+Quad2dStretchedInstancedOpenGl::Quad2dStretchedInstancedOpenGl(const std::shared_ptr<::BaseShaderProgramOpenGl> &shader)
     : shaderProgram(shader) {}
 
 bool Quad2dStretchedInstancedOpenGl::isReady() { return ready && (!usesTextureCoords || textureHolder) && !buffersNotReady; }
@@ -256,7 +255,8 @@ void Quad2dStretchedInstancedOpenGl::render(const std::shared_ptr<::RenderingCon
                                             const RenderPassConfig &renderPass,
                                             int64_t vpMatrix, int64_t mMatrix, const ::Vec3D &origin,
                                             bool isMasked, double screenPixelAsRealMeterFactor) {
-    if (!ready || (usesTextureCoords && !textureCoordsReady) || instanceCount == 0 || buffersNotReady) {
+    std::lock_guard<std::recursive_mutex> lock(dataMutex);
+    if (!ready || (usesTextureCoords && !textureCoordsReady) || instanceCount == 0 || buffersNotReady || !shaderProgram->isRenderable()) {
         return;
     }
 

--- a/android/src/main/cpp/graphics/objects/Quad2dStretchedInstancedOpenGl.h
+++ b/android/src/main/cpp/graphics/objects/Quad2dStretchedInstancedOpenGl.h
@@ -15,6 +15,7 @@
 #include "OpenGlContext.h"
 #include "Quad2dStretchedInstancedInterface.h"
 #include "ShaderProgramInterface.h"
+#include "BaseShaderProgramOpenGl.h"
 #include "opengl_wrapper.h"
 #include <mutex>
 #include <vector>
@@ -25,7 +26,7 @@ class Quad2dStretchedInstancedOpenGl : public GraphicsObjectInterface,
                      public Quad2dStretchedInstancedInterface,
                      public std::enable_shared_from_this<Quad2dStretchedInstancedOpenGl> {
   public:
-    Quad2dStretchedInstancedOpenGl(const std::shared_ptr<::ShaderProgramInterface> &shader);
+    Quad2dStretchedInstancedOpenGl(const std::shared_ptr<::BaseShaderProgramOpenGl> &shader);
 
     ~Quad2dStretchedInstancedOpenGl(){};
 
@@ -84,7 +85,7 @@ class Quad2dStretchedInstancedOpenGl : public GraphicsObjectInterface,
     void removeTextureCoordsGlBuffers();
 
     bool is3d = false;
-    std::shared_ptr<ShaderProgramInterface> shaderProgram;
+    std::shared_ptr<BaseShaderProgramOpenGl> shaderProgram;
     std::string programName;
     int program;
 

--- a/android/src/main/cpp/graphics/objects/Text2dInstancedOpenGl.cpp
+++ b/android/src/main/cpp/graphics/objects/Text2dInstancedOpenGl.cpp
@@ -12,9 +12,8 @@
 #include "Logger.h"
 #include "OpenGlHelper.h"
 #include "TextureHolderInterface.h"
-#include "BaseShaderProgramOpenGl.h"
 
-Text2dInstancedOpenGl::Text2dInstancedOpenGl(const std::shared_ptr<::ShaderProgramInterface> &shader)
+Text2dInstancedOpenGl::Text2dInstancedOpenGl(const std::shared_ptr<::BaseShaderProgramOpenGl> &shader)
         : shaderProgram(shader) {}
 
 bool Text2dInstancedOpenGl::isReady() { return ready && (!usesTextureCoords || textureHolder) && !buffersNotReady; }
@@ -256,7 +255,7 @@ void Text2dInstancedOpenGl::render(const std::shared_ptr<::RenderingContextInter
                                    int64_t vpMatrix, int64_t mMatrix, const ::Vec3D &origin,
                                    bool isMasked, double screenPixelAsRealMeterFactor) {
     std::lock_guard<std::recursive_mutex> lock(dataMutex);
-    if (!ready || (usesTextureCoords && !textureCoordsReady) || instanceCount == 0 || buffersNotReady) {
+    if (!ready || (usesTextureCoords && !textureCoordsReady) || instanceCount == 0 || buffersNotReady || !shaderProgram->isRenderable()) {
         return;
     }
 

--- a/android/src/main/cpp/graphics/objects/Text2dInstancedOpenGl.h
+++ b/android/src/main/cpp/graphics/objects/Text2dInstancedOpenGl.h
@@ -14,6 +14,7 @@
 #include "OpenGlContext.h"
 #include "TextInstancedInterface.h"
 #include "ShaderProgramInterface.h"
+#include "BaseShaderProgramOpenGl.h"
 #include "opengl_wrapper.h"
 #include <mutex>
 #include <vector>
@@ -23,7 +24,7 @@ class Text2dInstancedOpenGl : public GraphicsObjectInterface,
                               public TextInstancedInterface,
                               public std::enable_shared_from_this<Text2dInstancedOpenGl> {
 public:
-    Text2dInstancedOpenGl(const std::shared_ptr<::ShaderProgramInterface> &shader);
+    Text2dInstancedOpenGl(const std::shared_ptr<::BaseShaderProgramOpenGl> &shader);
 
     ~Text2dInstancedOpenGl(){};
 
@@ -79,7 +80,7 @@ protected:
     void removeTextureCoordsGlBuffers();
 
     bool is3d = false;
-    std::shared_ptr<ShaderProgramInterface> shaderProgram;
+    std::shared_ptr<BaseShaderProgramOpenGl> shaderProgram;
     std::string programName;
     int program;
 

--- a/android/src/main/cpp/graphics/objects/Text2dOpenGl.cpp
+++ b/android/src/main/cpp/graphics/objects/Text2dOpenGl.cpp
@@ -13,7 +13,7 @@
 #include "TextureHolderInterface.h"
 #include <cstring>
 
-Text2dOpenGl::Text2dOpenGl(const std::shared_ptr<::ShaderProgramInterface> &shader)
+Text2dOpenGl::Text2dOpenGl(const std::shared_ptr<::BaseShaderProgramOpenGl> &shader)
     : shaderProgram(shader) {}
 
 bool Text2dOpenGl::isReady() { return ready && textureHolder; }
@@ -223,7 +223,8 @@ void Text2dOpenGl::renderAsMask(const std::shared_ptr<::RenderingContextInterfac
 void Text2dOpenGl::render(const std::shared_ptr<::RenderingContextInterface> &context, const RenderPassConfig &renderPass,
                           int64_t vpMatrix, int64_t mMatrix, const ::Vec3D &origin, bool isMasked,
                           double screenPixelAsRealMeterFactor) {
-    if (!ready || !textureHolder) {
+    std::lock_guard<std::recursive_mutex> lock(dataMutex);
+    if (!ready || !textureHolder || !shaderProgram->isRenderable()) {
         return;
     }
 

--- a/android/src/main/cpp/graphics/objects/Text2dOpenGl.h
+++ b/android/src/main/cpp/graphics/objects/Text2dOpenGl.h
@@ -15,6 +15,7 @@
 #include "MaskingObjectInterface.h"
 #include "OpenGlContext.h"
 #include "ShaderProgramInterface.h"
+#include "BaseShaderProgramOpenGl.h"
 #include "TextDescription.h"
 #include "TextInterface.h"
 #include "opengl_wrapper.h"
@@ -26,7 +27,7 @@ class Text2dOpenGl : public GraphicsObjectInterface,
                      public TextInterface,
                      public std::enable_shared_from_this<Text2dOpenGl> {
   public:
-    Text2dOpenGl(const std::shared_ptr<::ShaderProgramInterface> &shader);
+    Text2dOpenGl(const std::shared_ptr<::BaseShaderProgramOpenGl> &shader);
 
     ~Text2dOpenGl(){};
 
@@ -63,7 +64,7 @@ protected:
 
     void removeGlBuffers();
 
-    std::shared_ptr<ShaderProgramInterface> shaderProgram;
+    std::shared_ptr<BaseShaderProgramOpenGl> shaderProgram;
     std::string programName;
     int program;
 

--- a/android/src/main/cpp/graphics/shader/BaseShaderProgramOpenGl.h
+++ b/android/src/main/cpp/graphics/shader/BaseShaderProgramOpenGl.h
@@ -38,6 +38,8 @@ public:
 
     virtual void clearGlObjects() {};
 
+    virtual bool isRenderable() { return true; }
+
 protected:
 
     virtual void setBlendMode(BlendMode blendMode) override;

--- a/android/src/main/cpp/graphics/shader/ColorLineGroup2dShaderOpenGl.cpp
+++ b/android/src/main/cpp/graphics/shader/ColorLineGroup2dShaderOpenGl.cpp
@@ -102,6 +102,11 @@ void ColorLineGroup2dShaderOpenGl::preRender(const std::shared_ptr<::RenderingCo
     }
 }
 
+bool ColorLineGroup2dShaderOpenGl::isRenderable() {
+    std::lock_guard<std::recursive_mutex> overlayLock(styleMutex);
+    return numStyles > 0;
+}
+
 void ColorLineGroup2dShaderOpenGl::setStyles(const ::SharedBytes & styles) {
     assert(styles.elementCount <= MAX_NUM_STYLES);
     assert(styles.elementCount * styles.bytesPerElement <= lineValues.size() * sizeof(float));

--- a/android/src/main/cpp/graphics/shader/ColorLineGroup2dShaderOpenGl.h
+++ b/android/src/main/cpp/graphics/shader/ColorLineGroup2dShaderOpenGl.h
@@ -32,11 +32,13 @@ public:
 
     virtual void setStyles(const ::SharedBytes & styles) override;
 
-    void setDashingScaleFactor(float factor) override;
+    virtual void setDashingScaleFactor(float factor) override;
 
-    void setupGlObjects(const std::shared_ptr<::OpenGlContext> &context) override;
+    virtual void setupGlObjects(const std::shared_ptr<::OpenGlContext> &context) override;
 
-    void clearGlObjects() override;
+    virtual void clearGlObjects() override;
+
+    virtual bool isRenderable() override;
 
 protected:
     virtual std::string getVertexShader() override;

--- a/android/src/main/cpp/graphics/shader/ColorPolygonGroup2dShaderOpenGl.cpp
+++ b/android/src/main/cpp/graphics/shader/ColorPolygonGroup2dShaderOpenGl.cpp
@@ -83,6 +83,11 @@ void ColorPolygonGroup2dShaderOpenGl::preRender(const std::shared_ptr<::Renderin
     }
 }
 
+bool ColorPolygonGroup2dShaderOpenGl::isRenderable() {
+    std::lock_guard<std::recursive_mutex> overlayLock(styleMutex);
+    return numStyles > 0;
+}
+
 void ColorPolygonGroup2dShaderOpenGl::setStyles(const ::SharedBytes & styles) {
     {
         std::lock_guard<std::recursive_mutex> overlayLock(styleMutex);

--- a/android/src/main/cpp/graphics/shader/ColorPolygonGroup2dShaderOpenGl.h
+++ b/android/src/main/cpp/graphics/shader/ColorPolygonGroup2dShaderOpenGl.h
@@ -36,6 +36,8 @@ class ColorPolygonGroup2dShaderOpenGl : public BaseShaderProgramOpenGl,
 
     void clearGlObjects() override;
 
+    virtual bool isRenderable() override;
+
   protected:
     virtual std::string getVertexShader() override;
 

--- a/shared/src/map/layers/tiled/vector/sourcemanagers/Tiled2dMapVectorSourceVectorTileDataManager.cpp
+++ b/shared/src/map/layers/tiled/vector/sourcemanagers/Tiled2dMapVectorSourceVectorTileDataManager.cpp
@@ -316,7 +316,7 @@ void Tiled2dMapVectorSourceVectorTileDataManager::reloadLayerContent(const std::
             Actor<Tiled2dMapVectorTile> actor = createTileActor(tileData.tileInfo, layerDescription);
             if (actor) {
                 if (auto strongSelectionDelegate = selectionDelegate.lock()) {
-                    actor.message(MFN(&Tiled2dMapVectorTile::setSelectionDelegate), strongSelectionDelegate);
+                    actor.unsafe()->setSelectionDelegate(strongSelectionDelegate);
                 }
 
                 if (subTiles->second.empty()) {


### PR DESCRIPTION
Introducing UBOs for OpenGL line/polygon groups has led to potentially uninitialized states in these buffers. To prevent shaders from rendering in such situations or when the buffers are in an unusable state, the GL graphics objects now query the shader's state. This allows for skipping the drawing of objects at the earliest possible moment, avoiding the need for the vertex or fragment shader to handle fundamentally invalid states and preventing unnecessary partial executions of the pipeline.
