### PR TITLE
MAP-54: Prioritize data loads per loader, so fallback cannot block primary

### DIFF
--- a/shared/public/Tiled2dMapRasterSource.h
+++ b/shared/public/Tiled2dMapRasterSource.h
@@ -18,7 +18,7 @@
 #include "Tiled2dMapRasterSourceListener.h"
 
 class Tiled2dMapRasterSource
-    : public Tiled2dMapSource<TextureHolderInterface, std::shared_ptr<TextureLoaderResult>, std::shared_ptr<::TextureHolderInterface>> {
+    : public Tiled2dMapSource<std::shared_ptr<TextureLoaderResult>, std::shared_ptr<::TextureHolderInterface>> {
   public:
     Tiled2dMapRasterSource(const MapConfig &mapConfig,
                            const std::shared_ptr<Tiled2dMapLayerConfig> &layerConfig,

--- a/shared/public/Tiled2dMapSource.h
+++ b/shared/public/Tiled2dMapSource.h
@@ -113,10 +113,9 @@ class Tiled2dMapSourceReadyInterface {
     virtual void setTileReady(const Tiled2dMapVersionedTileInfo &tile) = 0;
 };
 
-// T is the Object used for loading
 // L is the Loading type
 // R is the Result type
-template <class T, class L, class R>
+template <class L, class R>
 class Tiled2dMapSource : public Tiled2dMapSourceInterface,
                          public Tiled2dMapSourceReadyInterface,
                          public std::enable_shared_from_this<Tiled2dMapSourceInterface>,

--- a/shared/public/Tiled2dMapSource.h
+++ b/shared/public/Tiled2dMapSource.h
@@ -113,8 +113,16 @@ class Tiled2dMapSourceReadyInterface {
     virtual void setTileReady(const Tiled2dMapVersionedTileInfo &tile) = 0;
 };
 
-// L is the Loading type
+// L is the Loading type; std::shared_ptr to either DataLoaderResult or TextureLoaderResult (or compatible class).
 // R is the Result type
+//
+// NOTE: only include the implementation header Tile2dMapSourceImpl.h
+// selectively to avoid including this in too many compilation units.
+// Instantiate the template with the chosen type parameters for the derived class,
+// e.g. at the bottom of the .cpp of the derived class:
+//
+//  #include <Tiled2dMapSourceImpl.h>
+//  template class Tiled2dMapSource<std::shared_ptr<FooLoaderResult>, FooResultType>;
 template <class L, class R>
 class Tiled2dMapSource : public Tiled2dMapSourceInterface,
                          public Tiled2dMapSourceReadyInterface,
@@ -244,5 +252,3 @@ class Tiled2dMapSource : public Tiled2dMapSourceInterface,
 
     std::string layerName;
 };
-
-#include "Tiled2dMapSourceImpl.h"

--- a/shared/public/Tiled2dMapSource.h
+++ b/shared/public/Tiled2dMapSource.h
@@ -207,7 +207,7 @@ class Tiled2dMapSource : public Tiled2dMapSourceInterface,
 
     std::vector<VisibleTilesLayer> currentPyramid;
     int currentKeepZoomLevelOffset;
-    std::vector<PrioritizedTiled2dMapTileInfo> tilesRequestedToLoad;
+    std::vector<std::vector<Tiled2dMapTileInfo>> loadingQueues;
 
     std::vector<PolygonCoord> currentViewBounds = {};
     std::optional<RectCoord> currentViewBoundsRect = std::nullopt;

--- a/shared/public/Tiled2dMapSourceImpl.h
+++ b/shared/public/Tiled2dMapSourceImpl.h
@@ -41,8 +41,8 @@ template <> struct hash<VisibleTileCandidate> {
 };
 } // namespace std
 
-template <class T, class L, class R>
-Tiled2dMapSource<T, L, R>::Tiled2dMapSource(const MapConfig &mapConfig, const std::shared_ptr<Tiled2dMapLayerConfig> &layerConfig,
+template <class L, class R>
+Tiled2dMapSource<L, R>::Tiled2dMapSource(const MapConfig &mapConfig, const std::shared_ptr<Tiled2dMapLayerConfig> &layerConfig,
                                             const std::shared_ptr<CoordinateConversionHelperInterface> &conversionHelper,
                                             const std::shared_ptr<SchedulerInterface> &scheduler, float screenDensityPpi,
                                             size_t loaderCount, std::string layerName)
@@ -74,7 +74,7 @@ Tiled2dMapSource<T, L, R>::Tiled2dMapSource(const MapConfig &mapConfig, const st
 const static double VIEWBOUNDS_PADDING_MIN_DIM_PC = 0.15;
 const static int8_t ALWAYS_KEEP_LEVEL_TARGET_ZOOM_OFFSET = -8;
 
-template <class T, class L, class R> bool Tiled2dMapSource<T, L, R>::isTileVisible(const Tiled2dMapTileInfo &tileInfo) {
+template <class L, class R> bool Tiled2dMapSource<L, R>::isTileVisible(const Tiled2dMapTileInfo &tileInfo) {
     return currentVisibleTiles.count(tileInfo) > 0;
 }
 
@@ -84,9 +84,9 @@ template <typename T> static void hash_combine(size_t &seed, const T &value) {
     seed ^= v + 0x9e3779b9 + (seed << 6) + (seed >> 2);
 }
 
-template <class T, class L, class R>
-::Vec3D Tiled2dMapSource<T, L, R>::transformToView(const ::Coord &position, const std::vector<float> &viewMatrix,
-                                                   const Vec3D &origin) {
+template <class L, class R>
+::Vec3D Tiled2dMapSource<L, R>::transformToView(const ::Coord &position, const std::vector<float> &viewMatrix,
+                                                const Vec3D &origin) {
 
     Coord mapCoord = conversionHelper->convertToRenderSystem(position);
 
@@ -105,8 +105,8 @@ template <class T, class L, class R>
     return point2d;
 }
 
-template <class T, class L, class R>
-::Vec3D Tiled2dMapSource<T, L, R>::projectToScreen(const ::Vec3D &position, const std::vector<float> &projectionMatrix) {
+template <class L, class R>
+::Vec3D Tiled2dMapSource<L, R>::projectToScreen(const ::Vec3D &position, const std::vector<float> &projectionMatrix) {
     std::vector<float> inVec = {(float)position.x, (float)position.y, (float)position.z, 1.0};
     std::vector<float> outVec = {0, 0, 0, 0};
 
@@ -116,8 +116,8 @@ template <class T, class L, class R>
     return point2d;
 }
 
-template <class T, class L, class R>
-void Tiled2dMapSource<T, L, R>::onCameraChange(const std::vector<float> &viewMatrix, const std::vector<float> &projectionMatrix,
+template <class L, class R>
+void Tiled2dMapSource<L, R>::onCameraChange(const std::vector<float> &viewMatrix, const std::vector<float> &projectionMatrix,
                                                const ::Vec3D &origin, float verticalFov, float horizontalFov, float width,
                                                float height, float focusPointAltitude, const ::Coord &focusPointPosition,
                                                float zoom) {
@@ -648,8 +648,8 @@ void Tiled2dMapSource<T, L, R>::onCameraChange(const std::vector<float> &viewMat
     }
 }
 
-template <class T, class L, class R>
-void Tiled2dMapSource<T, L, R>::onVisibleBoundsChanged(const ::RectCoord &visibleBounds, int curT_, double zoom) {
+template <class L, class R>
+void Tiled2dMapSource<L, R>::onVisibleBoundsChanged(const ::RectCoord &visibleBounds, int curT_, double zoom) {
     if (isPaused) {
         return;
     }
@@ -904,8 +904,8 @@ void Tiled2dMapSource<T, L, R>::onVisibleBoundsChanged(const ::RectCoord &visibl
     currentViewBoundsRect = visibleBoundsLayer;
 }
 
-template <class T, class L, class R>
-void Tiled2dMapSource<T, L, R>::onVisibleTilesChanged(const std::vector<VisibleTilesLayer> &pyramid, bool enforceMultipleLevels,
+template <class L, class R>
+void Tiled2dMapSource<L, R>::onVisibleTilesChanged(const std::vector<VisibleTilesLayer> &pyramid, bool enforceMultipleLevels,
                                                       int keepZoomLevelOffset) {
     currentVisibleTiles.clear();
 
@@ -1034,16 +1034,16 @@ void Tiled2dMapSource<T, L, R>::onVisibleTilesChanged(const std::vector<VisibleT
     notifyTilesUpdates();
 }
 
-template <class T, class L, class R>
-void Tiled2dMapSource<T, L, R>::scheduleFixedNumberOfLoadingTasks() {
+template <class L, class R>
+void Tiled2dMapSource<L, R>::scheduleFixedNumberOfLoadingTasks() {
     while(tilesRequestedToLoad.size()>0 && currentlyLoading.size()<16){
         performLoadingTask(tilesRequestedToLoad[0].tileInfo, 0);
         tilesRequestedToLoad.erase(tilesRequestedToLoad.begin());
     }
 }
 
-template <class T, class L, class R>
-void Tiled2dMapSource<T, L, R>::performLoadingTask(Tiled2dMapTileInfo tile, size_t loaderIndex) {
+template <class L, class R>
+void Tiled2dMapSource<L, R>::performLoadingTask(Tiled2dMapTileInfo tile, size_t loaderIndex) {
     if (currentlyLoading.count(tile) != 0)
         return;
 
@@ -1105,8 +1105,8 @@ void Tiled2dMapSource<T, L, R>::performLoadingTask(Tiled2dMapTileInfo tile, size
     });
 }
 
-template <class T, class L, class R>
-void Tiled2dMapSource<T, L, R>::didLoad(Tiled2dMapTileInfo tile, size_t loaderIndex, const R &result) {
+template <class L, class R>
+void Tiled2dMapSource<L, R>::didLoad(Tiled2dMapTileInfo tile, size_t loaderIndex, const R &result) {
     currentlyLoading.erase(tile);
     scheduleFixedNumberOfLoadingTasks();
 
@@ -1141,8 +1141,8 @@ void Tiled2dMapSource<T, L, R>::didLoad(Tiled2dMapTileInfo tile, size_t loaderIn
     notifyTilesUpdates();
 }
 
-template <class T, class L, class R>
-void Tiled2dMapSource<T, L, R>::didFailToLoad(Tiled2dMapTileInfo tile, size_t loaderIndex, const LoaderStatus &status,
+template <class L, class R>
+void Tiled2dMapSource<L, R>::didFailToLoad(Tiled2dMapTileInfo tile, size_t loaderIndex, const LoaderStatus &status,
                                               const std::optional<std::string> &errorCode) {
     currentlyLoading.erase(tile);
 
@@ -1224,7 +1224,7 @@ void Tiled2dMapSource<T, L, R>::didFailToLoad(Tiled2dMapTileInfo tile, size_t lo
     notifyTilesUpdates();
 }
 
-template <class T, class L, class R> void Tiled2dMapSource<T, L, R>::performDelayedTasks() {
+template <class L, class R> void Tiled2dMapSource<L, R>::performDelayedTasks() {
     nextDelayTaskExecution = std::nullopt;
 
     const auto now = DateHelper::currentTimeMillis();
@@ -1263,7 +1263,7 @@ template <class T, class L, class R> void Tiled2dMapSource<T, L, R>::performDela
     }
 }
 
-template <class T, class L, class R> void Tiled2dMapSource<T, L, R>::updateTileMasks() {
+template <class L, class R> void Tiled2dMapSource<L, R>::updateTileMasks() {
 
     if (!zoomInfo.maskTile) {
         for (auto it = currentTiles.rbegin(); it != currentTiles.rend(); it++) {
@@ -1360,7 +1360,7 @@ template <class T, class L, class R> void Tiled2dMapSource<T, L, R>::updateTileM
     }
 }
 
-template <class T, class L, class R> void Tiled2dMapSource<T, L, R>::setTileReady(const Tiled2dMapVersionedTileInfo &tile) {
+template <class L, class R> void Tiled2dMapSource<L, R>::setTileReady(const Tiled2dMapVersionedTileInfo &tile) {
     bool needsUpdate = false;
 
     if (readyTiles.count(tile.tileInfo) == 0) {
@@ -1380,8 +1380,8 @@ template <class T, class L, class R> void Tiled2dMapSource<T, L, R>::setTileRead
     notifyTilesUpdates();
 }
 
-template <class T, class L, class R>
-void Tiled2dMapSource<T, L, R>::setTilesReady(const std::vector<Tiled2dMapVersionedTileInfo> &tiles) {
+template <class L, class R>
+void Tiled2dMapSource<L, R>::setTilesReady(const std::vector<Tiled2dMapVersionedTileInfo> &tiles) {
     bool needsUpdate = false;
 
     for (auto const &tile : tiles) {
@@ -1406,27 +1406,27 @@ void Tiled2dMapSource<T, L, R>::setTilesReady(const std::vector<Tiled2dMapVersio
     notifyTilesUpdates();
 }
 
-template <class T, class L, class R> void Tiled2dMapSource<T, L, R>::setMinZoomLevelIdentifier(std::optional<int32_t> value) {
+template <class L, class R> void Tiled2dMapSource<L, R>::setMinZoomLevelIdentifier(std::optional<int32_t> value) {
     minZoomLevelIdentifier = value;
 }
 
-template <class T, class L, class R> void Tiled2dMapSource<T, L, R>::setMaxZoomLevelIdentifier(std::optional<int32_t> value) {
+template <class L, class R> void Tiled2dMapSource<L, R>::setMaxZoomLevelIdentifier(std::optional<int32_t> value) {
     maxZoomLevelIdentifier = value;
 }
 
-template <class T, class L, class R> std::optional<int32_t> Tiled2dMapSource<T, L, R>::getMinZoomLevelIdentifier() {
+template <class L, class R> std::optional<int32_t> Tiled2dMapSource<L, R>::getMinZoomLevelIdentifier() {
     return minZoomLevelIdentifier;
 }
 
-template <class T, class L, class R> std::optional<int32_t> Tiled2dMapSource<T, L, R>::getMaxZoomLevelIdentifier() {
+template <class L, class R> std::optional<int32_t> Tiled2dMapSource<L, R>::getMaxZoomLevelIdentifier() {
     return maxZoomLevelIdentifier;
 }
 
-template <class T, class L, class R> void Tiled2dMapSource<T, L, R>::pause() { isPaused = true; }
+template <class L, class R> void Tiled2dMapSource<L, R>::pause() { isPaused = true; }
 
-template <class T, class L, class R> void Tiled2dMapSource<T, L, R>::resume() { isPaused = false; }
+template <class L, class R> void Tiled2dMapSource<L, R>::resume() { isPaused = false; }
 
-template <class T, class L, class R>::LayerReadyState Tiled2dMapSource<T, L, R>::isReadyToRenderOffscreen() {
+template <class L, class R>::LayerReadyState Tiled2dMapSource<L, R>::isReadyToRenderOffscreen() {
     if (notFoundTiles.size() > 0) {
         return LayerReadyState::ERROR;
     }
@@ -1457,12 +1457,12 @@ template <class T, class L, class R>::LayerReadyState Tiled2dMapSource<T, L, R>:
     return LayerReadyState::READY;
 }
 
-template <class T, class L, class R>
-void Tiled2dMapSource<T, L, R>::setErrorManager(const std::shared_ptr<::ErrorManager> &errorManager) {
+template <class L, class R>
+void Tiled2dMapSource<L, R>::setErrorManager(const std::shared_ptr<::ErrorManager> &errorManager) {
     this->errorManager = errorManager;
 }
 
-template <class T, class L, class R> void Tiled2dMapSource<T, L, R>::forceReload() {
+template <class L, class R> void Tiled2dMapSource<L, R>::forceReload() {
 
     // set delay to 0 for all error tiles
     for (auto &[loaderIndex, errors] : errorTiles) {
@@ -1475,7 +1475,7 @@ template <class T, class L, class R> void Tiled2dMapSource<T, L, R>::forceReload
     onVisibleTilesChanged(currentPyramid, currentKeepZoomLevelOffset);
 }
 
-template <class T, class L, class R> void Tiled2dMapSource<T, L, R>::reloadTiles() {
+template <class L, class R> void Tiled2dMapSource<L, R>::reloadTiles() {
     outdatedTiles.clear();
     outdatedTiles.swap(currentTiles);
     readyTiles.clear();

--- a/shared/public/Tiled2dMapVectorSource.h
+++ b/shared/public/Tiled2dMapVectorSource.h
@@ -20,9 +20,8 @@
 #include <vector>
 #include "DataRef.hpp"
 
-class Tiled2dMapVectorSource : public Tiled2dMapSource<std::shared_ptr<djinni::DataRef>,
-                                                        std::shared_ptr<DataLoaderResult>,
-                                                        Tiled2dMapVectorTileInfo::FeatureMap>  {
+class Tiled2dMapVectorSource : public Tiled2dMapSource<std::shared_ptr<DataLoaderResult>,
+                                                       Tiled2dMapVectorTileInfo::FeatureMap> {
 public:
     Tiled2dMapVectorSource(const MapConfig &mapConfig,
                            const std::shared_ptr<Tiled2dMapLayerConfig> &layerConfig,

--- a/shared/public/VectorSet.h
+++ b/shared/public/VectorSet.h
@@ -1,5 +1,6 @@
-#include <vector>
+#include <algorithm>
 #include <memory>
+#include <vector>
 
 #pragma once
 

--- a/shared/src/map/layers/tiled/raster/Tiled2dMapRasterSource.cpp
+++ b/shared/src/map/layers/tiled/raster/Tiled2dMapRasterSource.cpp
@@ -22,7 +22,7 @@ Tiled2dMapRasterSource::Tiled2dMapRasterSource(const MapConfig &mapConfig,
                                                const WeakActor<Tiled2dMapRasterSourceListener> &listener,
                                                float screenDensityPpi,
                                                std::string layerName)
-    : Tiled2dMapSource<TextureHolderInterface, std::shared_ptr<TextureLoaderResult>, std::shared_ptr<::TextureHolderInterface>>(
+    : Tiled2dMapSource<std::shared_ptr<TextureLoaderResult>, std::shared_ptr<::TextureHolderInterface>>(
           mapConfig, layerConfig, conversionHelper, scheduler, screenDensityPpi, loaders.size(), layerName)
 , loaders(loaders)
 , rasterLayerActor(listener){}

--- a/shared/src/map/layers/tiled/raster/Tiled2dMapRasterSource.cpp
+++ b/shared/src/map/layers/tiled/raster/Tiled2dMapRasterSource.cpp
@@ -9,8 +9,6 @@
  */
 
 #include "Tiled2dMapRasterSource.h"
-#include "LambdaTask.h"
-#include <algorithm>
 #include <cmath>
 #include <string>
 
@@ -65,3 +63,7 @@ VectorSet<Tiled2dMapRasterTileInfo> Tiled2dMapRasterSource::getCurrentTiles() {
 
     return currentTileInfos;
 }
+
+#include "Tiled2dMapSourceImpl.h"
+template class Tiled2dMapSource<std::shared_ptr<TextureLoaderResult>, std::shared_ptr<::TextureHolderInterface>>;
+

--- a/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayer.cpp
+++ b/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayer.cpp
@@ -396,7 +396,6 @@ void Tiled2dMapVectorLayer::initializeVectorLayer() {
                                                                    layerConfig,
                                                                    mapInterface->getCoordinateConverterHelper(),
                                                                    mapInterface->getScheduler(),
-                                                                   loaders,
                                                                    selfVectorActor,
                                                                    layers,
                                                                    source,

--- a/shared/src/map/layers/tiled/vector/Tiled2dMapVectorSource.cpp
+++ b/shared/src/map/layers/tiled/vector/Tiled2dMapVectorSource.cpp
@@ -162,3 +162,6 @@ std::string Tiled2dMapVectorSource::getSourceName() {
     return sourceName;
 }
 
+#include "Tiled2dMapSourceImpl.h"
+template class Tiled2dMapSource<std::shared_ptr<DataLoaderResult>, Tiled2dMapVectorTileInfo::FeatureMap>;
+

--- a/shared/src/map/layers/tiled/vector/Tiled2dMapVectorSource.cpp
+++ b/shared/src/map/layers/tiled/vector/Tiled2dMapVectorSource.cpp
@@ -25,7 +25,7 @@ Tiled2dMapVectorSource::Tiled2dMapVectorSource(const MapConfig &mapConfig,
                                                const std::string &sourceName,
                                                float screenDensityPpi,
                                                std::string layerName)
-        : Tiled2dMapSource<std::shared_ptr<djinni::DataRef>, std::shared_ptr<DataLoaderResult>, Tiled2dMapVectorTileInfo::FeatureMap>(mapConfig, layerConfig, conversionHelper, scheduler, screenDensityPpi, tileLoaders.size(), layerName),
+        : Tiled2dMapSource<std::shared_ptr<DataLoaderResult>, Tiled2dMapVectorTileInfo::FeatureMap>(mapConfig, layerConfig, conversionHelper, scheduler, screenDensityPpi, tileLoaders.size(), layerName),
 loaders(tileLoaders), layersToDecode(layersToDecode), listener(listener), sourceName(sourceName) {}
 
 ::djinni::Future<std::shared_ptr<DataLoaderResult>> Tiled2dMapVectorSource::loadDataAsync(Tiled2dMapTileInfo tile, size_t loaderIndex) {

--- a/shared/src/map/layers/tiled/vector/geojson/Tiled2dVectorGeoJsonSource.h
+++ b/shared/src/map/layers/tiled/vector/geojson/Tiled2dVectorGeoJsonSource.h
@@ -11,18 +11,17 @@
 
 #pragma once
 
-#include "Tiled2dMapSource.h"
 #include "DataLoaderResult.h"
 #include "LoaderInterface.h"
-#include "Tiled2dMapVectorTileInfo.h"
+#include "MapCameraInterface.h"
+#include "Tiled2dMapVectorSource.h"
 #include "Tiled2dMapVectorSourceListener.h"
+#include "Tiled2dMapVectorTileInfo.h"
+
+#include <memory>
 #include <unordered_map>
 #include <vector>
-#include "DataRef.hpp"
-#include "geojsonvt.hpp"
-#include "Tiled2dMapVectorSource.h"
-#include "VectorMapSourceDescription.h"
-#include "Tiled2dMapVectorGeoJSONLayerConfig.h"
+#include <string>
 
 class Tiled2dVectorGeoJsonSource : public Tiled2dMapVectorSource, public GeoJSONTileDelegate  {
 public:
@@ -31,15 +30,19 @@ public:
                                const std::shared_ptr<Tiled2dMapLayerConfig> &layerConfig,
                                const std::shared_ptr<CoordinateConversionHelperInterface> &conversionHelper,
                                const std::shared_ptr<SchedulerInterface> &scheduler,
-                               const std::vector<std::shared_ptr<::LoaderInterface>> & tileLoaders,
                                const WeakActor<Tiled2dMapVectorSourceListener> &listener,
                                const std::unordered_set<std::string> &layersToDecode,
                                const std::string &sourceName,
                                float screenDensityPpi,
                                std::shared_ptr<GeoJSONVTInterface> geoJson,
-                               std::string layerName) :
-    Tiled2dMapVectorSource(mapConfig, layerConfig, conversionHelper, scheduler, tileLoaders, listener, layersToDecode, sourceName, screenDensityPpi, layerName),
-    geoJson(geoJson), camera(camera) {}
+                               std::string layerName)
+      : Tiled2dMapVectorSource(mapConfig, layerConfig, conversionHelper, scheduler,
+                               // fake loader entry so that Tiled2dMapSource sees one loader; loadDataAsync in this class does not use loader.
+                               std::vector<std::shared_ptr<LoaderInterface>>{nullptr},
+                               listener, layersToDecode, sourceName,
+                               screenDensityPpi, layerName)
+      , geoJson(geoJson)
+      , camera(camera) {}
 
     VectorSet<Tiled2dMapVectorTileInfo> getCurrentTiles() {
         VectorSet<Tiled2dMapVectorTileInfo> currentTileInfos;

--- a/shared/test/TestTileSource.cpp
+++ b/shared/test/TestTileSource.cpp
@@ -15,7 +15,7 @@ struct TestLoaderResult final {
     std::optional<std::string> errorCode = std::nullopt;
 };
 
-class TestTiled2dMapVectorSource : public Tiled2dMapSource<int, std::shared_ptr<TestLoaderResult>, int> {
+class TestTiled2dMapVectorSource : public Tiled2dMapSource<std::shared_ptr<TestLoaderResult>, int> {
   public:
     TestTiled2dMapVectorSource(const std::shared_ptr<TestScheduler> scheduler)
         : Tiled2dMapSource(MapConfig(CoordinateSystemFactory::getEpsg3857System()),

--- a/shared/test/TestTileSource.cpp
+++ b/shared/test/TestTileSource.cpp
@@ -6,6 +6,8 @@
 #include "WebMercatorTiled2dMapLayerConfig.h"
 #include "helper/TestScheduler.h"
 
+#include "Tiled2dMapSourceImpl.h"
+
 #include <catch2/benchmark/catch_benchmark.hpp>
 #include <catch2/catch_get_random_seed.hpp>
 #include <catch2/catch_test_macros.hpp>

--- a/shared/test/helper/TestScheduler.h
+++ b/shared/test/helper/TestScheduler.h
@@ -1,16 +1,23 @@
 #include "SchedulerInterface.h"
+#include "TaskConfig.h"
+#include "TaskInterface.h"
 #include <deque>
+#include <queue>
 
 class TestScheduler : public SchedulerInterface {
   public:
     virtual void addTask(const /*not-null*/ std::shared_ptr<TaskInterface> &task) override {
         std::lock_guard<std::mutex> guard(tasksMutex);
-        tasks.push_back(task);
+        auto taskConfig = task->getConfig();
+        if (taskConfig.delay <= 0) {
+            tasks.push_back(task);
+        } else {
+            delayedTasks.emplace(now + taskConfig.delay, task);
+        }
     }
     virtual void addTasks(const std::vector</*not-null*/ std::shared_ptr<TaskInterface>> &tasks) override {
-        std::lock_guard<std::mutex> guard(tasksMutex);
         for (auto task : tasks) {
-            this->tasks.push_back(task);
+            addTask(task);
         }
     }
     virtual void removeTask(const std::string &id) override {}
@@ -23,7 +30,55 @@ class TestScheduler : public SchedulerInterface {
     virtual void setSchedulerGraphicsTaskCallbacks(const std::shared_ptr<SchedulerGraphicsTaskCallbacks> &callbacks) override {}
 
   public:
-    bool process_one() {
+    // Process tasks, including delayed tasks, until there is nothing left to do
+    void drain() {
+        while (processOneFromQueue(tasks) || processOneDelayedTaskBefore(INT64_MAX)) {
+        }
+    }
+
+    // Process tasks including delayed tasks scheduled to execute before `until`, until there is nothing left to do.
+    void drainUntil(int64_t until) {
+        {
+            std::lock_guard<std::mutex> guard(tasksMutex);
+            now = until;
+        }
+        while (processOneFromQueue(tasks) || processOneDelayedTaskBefore(until)) {
+        }
+    }
+
+    // Process tasks until the scheduled time of the next delayed task
+    void stepUntilNextDelayed() {
+        int64_t until;
+        {
+            std::lock_guard<std::mutex> guard(tasksMutex);
+            if (delayedTasks.empty()) {
+                return;
+            }
+            until = delayedTasks.top().when;
+        }
+        drainUntil(until);
+    }
+
+  private:
+    bool processOneDelayedTaskBefore(int64_t until) {
+        std::shared_ptr<TaskInterface> task;
+        {
+            std::lock_guard<std::mutex> guard(tasksMutex);
+            if (delayedTasks.empty()) {
+                return false;
+            }
+            auto &top = delayedTasks.top();
+            if (top.when > until) {
+                return false;
+            }
+            task = top.task;
+            delayedTasks.pop();
+        }
+        task->run();
+        return true;
+    }
+
+    bool processOneFromQueue(std::deque<std::shared_ptr<TaskInterface>> &taskQueue) {
         std::shared_ptr<TaskInterface> task;
         {
             std::lock_guard<std::mutex> guard(tasksMutex);
@@ -37,12 +92,18 @@ class TestScheduler : public SchedulerInterface {
         return true;
     }
 
-    void drain() {
-        while (process_one()) {
-        }
-    }
+  private:
+    struct DelayedTask {
+        int64_t when;
+        std::shared_ptr<TaskInterface> task;
+
+        bool operator<(const DelayedTask &o) const { return when < o.when; }
+    };
 
   private:
     std::mutex tasksMutex;
     std::deque<std::shared_ptr<TaskInterface>> tasks;
+    std::priority_queue<DelayedTask> delayedTasks;
+
+    int64_t now = 0; // simulated time in seconds for delayed tasks, starting from 0.
 };


### PR DESCRIPTION
In 5d95aef, a limit to the number of concurrent tile loads was introduced. As a fallback to the next loader in the loader cascade was performed immediately, slow "fallback" loaders could block the subsequent tile loads from the "primary" loaders.
In the somewhat common loader cascade setup to load from offline data first and then fallback to a remote request, blocking the local loads with a slow remote loader can be disastrous.

For now, we keep the same fixed number of concurrent load "slots" and strictly prioritize by loader index. That is, all loads for loader 0 are processed before the loads for loader 1, etc.
Alternatively, the slots could be divided in any scheme among the loaders, as long as the primary loader is never starved.

The Tiled2dMapSource now has to explicitly handle a NOP from the last loader, and the case that no loaders are configured; this is now treated like "not found".

Related to this, also, is that Tiled2dVectorGeoJsonSource now sets loaderCount to exactly 1, via an unused dummy loader entry in the initialization of its base class.
