### PR TITLE
Uses private storage mode for stencil buffer

### DIFF
--- a/ios/graphics/Pipelines/RenderToImageRenderPass.swift
+++ b/ios/graphics/Pipelines/RenderToImageRenderPass.swift
@@ -82,6 +82,8 @@ class RenderToImageRenderPass {
             height: Int(size.height),
             mipmapped: false
         )
+
+        descriptor.storageMode = .private
         descriptor.usage = [.renderTarget]
         return device.makeTexture(descriptor: descriptor)
     }


### PR DESCRIPTION
- Prevents Crashes on Simulator where Shared Stencil buffers are not possible
- Changing a stencil buffer from Shared to Private moves its memory from being accessible by both CPU and GPU to being optimized solely for the GPU, making rendering faster but preventing direct CPU access. Direct CPU access is not needed for "toImageRendering", so this is not needed anyway.