### PR TITLE
Make Uniform Buffer Object handling compatible with WebGL

### DIFF
--- a/android/src/main/cpp/graphics/shader/ColorLineGroup2dShaderOpenGl.cpp
+++ b/android/src/main/cpp/graphics/shader/ColorLineGroup2dShaderOpenGl.cpp
@@ -46,14 +46,22 @@ void ColorLineGroup2dShaderOpenGl::setupProgram(const std::shared_ptr<::Renderin
     glLinkProgram(program); // create OpenGL program executables
 
     openGlContext->storeProgram(programName, program);
+
+    // Bind LineStyleCollection at binding index 0
+    GLuint lineStyleUniformBlockIdx = glGetUniformBlockIndex(program, "LineStyleCollection");
+    if (lineStyleUniformBlockIdx == GL_INVALID_INDEX) {
+        LogError <<= "Uniform block LineStyleCollection not found";
+    }
+    glUniformBlockBinding(program, lineStyleUniformBlockIdx, 0);
 }
 
 void ColorLineGroup2dShaderOpenGl::setupGlObjects(const std::shared_ptr<::OpenGlContext> &context) {
     if (lineStyleBuffer == 0) {
         glGenBuffers(1, &lineStyleBuffer);
         glBindBuffer(GL_UNIFORM_BUFFER, lineStyleBuffer);
-        // maximum number of polygonStyles and numStyles
-        glBufferData(GL_UNIFORM_BUFFER, sizeLineValuesArray * sizeof(GLfloat) + sizeof(GLint), nullptr, GL_DYNAMIC_DRAW);
+        // maximum number of polygonStyles and numStyles, padded to 16 byte alignment
+        glBufferData(GL_UNIFORM_BUFFER, sizeLineValuesArray * sizeof(GLfloat) + sizeof(GLint) + 3 * sizeof(GLint), nullptr,
+                     GL_DYNAMIC_DRAW);
         glBindBuffer(GL_UNIFORM_BUFFER, 0);
     }
 
@@ -142,9 +150,9 @@ std::string ColorLineGroup2dShaderOpenGl::getLineStylesUBODefinition(bool isSimp
                     float capType; // 7
                 };
 
-                layout (std140, binding = 0) uniform LineStyleCollection {
+                layout (std140) uniform LineStyleCollection {
                     SimpleLineStyle lineValues[) + std::to_string(MAX_NUM_STYLES) + OMMShaderCode(];
-                    int numStyles;
+                    lowp int numStyles;
                 } uLineStyles;
         );
     } else {
@@ -175,9 +183,9 @@ std::string ColorLineGroup2dShaderOpenGl::getLineStylesUBODefinition(bool isSimp
                     float dottedSkew; // 22
                 };
 
-                layout (std140, binding = 0) uniform LineStyleCollection {
+                layout (std140) uniform LineStyleCollection {
                     LineStyle lineValues[) + std::to_string(MAX_NUM_STYLES) + OMMShaderCode(];
-                    int numStyles;
+                    lowp int numStyles;
                 } uLineStyles;
         );
     }

--- a/android/src/main/cpp/graphics/shader/ColorPolygonGroup2dShaderOpenGl.cpp
+++ b/android/src/main/cpp/graphics/shader/ColorPolygonGroup2dShaderOpenGl.cpp
@@ -43,14 +43,22 @@ void ColorPolygonGroup2dShaderOpenGl::setupProgram(const std::shared_ptr<::Rende
     glLinkProgram(program); // create OpenGL program executables
 
     openGlContext->storeProgram(programName, program);
+
+    // Bind PolygonStyleCollection at binding index 0
+    GLuint blockIdx = glGetUniformBlockIndex(program, "PolygonStyleCollection");
+    if (blockIdx == GL_INVALID_INDEX) {
+        LogError <<= "Uniform block PolygonStyleCollection not found";
+    }
+    glUniformBlockBinding(program, blockIdx, 0);
 }
 
 void ColorPolygonGroup2dShaderOpenGl::setupGlObjects(const std::shared_ptr<::OpenGlContext> &context) {
     if (polygonStyleBuffer == 0) {
         glGenBuffers(1, &polygonStyleBuffer);
         glBindBuffer(GL_UNIFORM_BUFFER, polygonStyleBuffer);
-        // maximum number of polygonStyles and numStyles
-        glBufferData(GL_UNIFORM_BUFFER, sizeStyleValuesArray * sizeof(GLfloat) + sizeof(GLint), nullptr, GL_DYNAMIC_DRAW);
+        // maximum number of polygonStyles and numStyles, padded to 16 byte alignment
+        glBufferData(GL_UNIFORM_BUFFER, sizeStyleValuesArray * sizeof(GLfloat) + sizeof(GLint) + 3 * sizeof(GLint), nullptr,
+                     GL_DYNAMIC_DRAW);
         glBindBuffer(GL_UNIFORM_BUFFER, 0);
     }
 
@@ -114,9 +122,10 @@ std::string ColorPolygonGroup2dShaderOpenGl::getPolygonStylesUBODefinition(bool 
                     float gapWidth; // 6
                 }; // padded to 8 floats
 
-                layout (std140, binding = 0) uniform PolygonStyleCollection {
+                layout (std140) uniform PolygonStyleCollection {
                     StripedPolygonStyle polygonStyles[) + std::to_string(MAX_NUM_STYLES) + OMMShaderCode(];
-                    int numStyles;
+                    lowp int numStyles;
+                    // padding
                 } uPolygonStyles;
         );
     } else {
@@ -129,9 +138,10 @@ std::string ColorPolygonGroup2dShaderOpenGl::getPolygonStylesUBODefinition(bool 
                     float opacity; // 4
                 }; // padded to 8 floats
 
-                layout (std140, binding = 0) uniform PolygonStyleCollection {
+                layout (std140) uniform PolygonStyleCollection {
                     PolygonStyle polygonStyles[) + std::to_string(MAX_NUM_STYLES) + OMMShaderCode(];
-                    int numStyles;
+                    lowp int numStyles;
+                    // padding
                 } uPolygonStyles;
         );
     }


### PR DESCRIPTION
- layout(binding = 0) is not supported, use glUniformBlockBinding instead
- Uniform block data may require padding after last toplevel block entry. This seems to always be the case with std140 layout. WebGL enforces this strictly. Technically, providing a too small buffer is undefined behaviour.
- Explicitly set precision qualifier for numStyles. Otherwise, vertex and fragment shader default to incompatible precision settings in WebGL, and the program fails to link.