### PR TITLE
Explicitly pass std::weak_ptr in Mailbox Message

### DIFF
--- a/shared/public/Tiled2dMapSourceImpl.h
+++ b/shared/public/Tiled2dMapSourceImpl.h
@@ -11,13 +11,15 @@
 #include "DateHelper.h"
 #include "Tiled2dMapSource.h"
 #include "TiledLayerError.h"
-#include <algorithm>
 
 #include "Matrix.h"
 #include "PolygonCoord.h"
 #include "Vec2DHelper.h"
 #include "Vec3DHelper.h"
 #include "gpc.h"
+
+#include <algorithm>
+#include <queue>
 
 struct VisibleTileCandidate {
     int x;


### PR DESCRIPTION
Extracted code cleanup from obsolete PR
https://github.com/openmobilemaps/maps-core/pull/659.

Explicitly pass std::weak_ptr<Object> instead of hiding this in the template parameter type. No functional change.

Also, make it explicit that AskMessage does not support the replaceNew (de)duplication-strategy.