### PR TITLE
Release 3.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for Open Mobile Maps
 
+## Version 3.1.3
+- Fixed an unsafe layer accessing during drawReadyFrame
+- Added coarse cooperative cancelling in the Android MapRenderHelper
+
 ## Version 3.1.2
 - Improved offscreen rendering on iOS
 - Fixed an issue with OpenGL line and polygon styles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog for Open Mobile Maps
 
 ## Version 3.1.3
-- Fixed an unsafe layer accessing during drawReadyFrame
+- Fixed several unsafe layer accesses in MapScene
 - Added coarse cooperative cancelling in the Android MapRenderHelper
 
 ## Version 3.1.2

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -31,8 +31,8 @@ SNAPSHOT_REPOSITORY_URL=https://oss.sonatype.org/content/repositories/snapshots/
 
 GROUP=io.openmobilemaps
 POM_ARTIFACT_ID=mapscore
-VERSION_NAME=3.1.2
-VERSION_CODE=3010200
+VERSION_NAME=3.1.3
+VERSION_CODE=3010300
 
 POM_NAME=mapscore
 POM_PACKAGING=aar

--- a/android/readme.md
+++ b/android/readme.md
@@ -64,7 +64,7 @@ This library is available on MavenCentral. To add it to your Android project, ad
 
 ```
 dependencies {
-  implementation 'io.openmobilemaps:mapscore:3.1.2'
+  implementation 'io.openmobilemaps:mapscore:3.1.3'
 }
 ```
 

--- a/ios/readme.md
+++ b/ios/readme.md
@@ -31,7 +31,7 @@ For App integration within XCode, add this package to your App target. To do thi
 Once you have your Swift package set up, adding Open Mobile Maps as a dependency is as easy as adding it to the dependencies value of your Package.swift.
 ```swift
 dependencies: [
-    .package(url: "https://github.com/openmobilemaps/maps-core", from: .init(stringLiteral: "3.1.2"))
+    .package(url: "https://github.com/openmobilemaps/maps-core", from: .init(stringLiteral: "3.1.3"))
 ]
 ```
 

--- a/shared/src/MapsCoreSharedModule.cpp
+++ b/shared/src/MapsCoreSharedModule.cpp
@@ -10,4 +10,4 @@
 
 #include "MapsCoreSharedModule.h"
 
-std::string MapsCoreSharedModule::version() { return "3.1.2"; }
+std::string MapsCoreSharedModule::version() { return "3.1.3"; }

--- a/shared/src/map/MapScene.cpp
+++ b/shared/src/map/MapScene.cpp
@@ -476,8 +476,11 @@ void MapScene::drawReadyFrame(const ::RectCoord &bounds, float paddingPc, float 
 
     // for now we only support drawing a ready frame, therefore
     // we disable animations in the layers
-    for (const auto &layer : layers) {
-        layer.second->enableAnimations(false);
+    {
+        std::lock_guard<std::recursive_mutex> lock(layersMutex);
+        for (const auto &layer: layers) {
+            layer.second->enableAnimations(false);
+        }
     }
 
     auto state = LayerReadyState::NOT_READY;
@@ -521,8 +524,11 @@ void MapScene::drawReadyFrame(const ::RectCoord &bounds, float paddingPc, float 
     // re-enable animations if the map scene is used not only for
     // drawReadyFrame
     camera->freeze(false);
-    for (const auto &layer : layers) {
-        layer.second->enableAnimations(true);
+    {
+        std::lock_guard<std::recursive_mutex> lock(layersMutex);
+        for (const auto &layer: layers) {
+            layer.second->enableAnimations(true);
+        }
     }
 }
 

--- a/shared/src/map/MapScene.cpp
+++ b/shared/src/map/MapScene.cpp
@@ -104,16 +104,22 @@ std::vector<std::shared_ptr<::PerformanceLoggerInterface>> MapScene::getPerforma
 
 std::vector<std::shared_ptr<LayerInterface>> MapScene::getLayers() {
     std::vector<std::shared_ptr<LayerInterface>> layersList;
-    for (const auto &l : layers) {
-        layersList.emplace_back(l.second);
+    {
+        std::lock_guard<std::recursive_mutex> lock(layersMutex);
+        for (const auto &l: layers) {
+            layersList.emplace_back(l.second);
+        }
     }
     return layersList;
 };
 
 std::vector<std::shared_ptr<IndexedLayerInterface>> MapScene::getLayersIndexed() {
     std::vector<std::shared_ptr<IndexedLayerInterface>> layersList;
-    for (const auto &l : layers) {
-        layersList.emplace_back(std::make_shared<IndexedLayer>(l.first, l.second));
+    {
+        std::lock_guard<std::recursive_mutex> lock(layersMutex);
+        for (const auto &l: layers) {
+            layersList.emplace_back(std::make_shared<IndexedLayer>(l.first, l.second));
+        }
     }
     return layersList;
 }


### PR DESCRIPTION
Including fix: 
- Properly lock layer access in drawReadyFrame, cooperatively cancel offscreen rendering with inactive coroutine context on Android.