### PR TITLE
"fixes" semaphore that can happen on dealloc of mapView

### DIFF
--- a/ios/maps/MCMapView.swift
+++ b/ios/maps/MCMapView.swift
@@ -79,6 +79,10 @@ open class MCMapView: MTKView {
     }
 
     deinit {
+        // nasty workaround for the dispatch_semaphore crash
+        for _ in 0..<3 {
+            renderSemaphore.signal()
+        }
         if Thread.isMainThread {
             // make sure the mapInterface is destroyed from a background thread
             DispatchQueue.global()


### PR DESCRIPTION
If MCMapView is deallocated before all three GPU buffers have finished, the following assertion is triggered:
`BUG IN CLIENT OF LIBDISPATCH: Semaphore object deallocated while in use (current value < original value)`
This causes the app to crash.
Unfortunately, the only solution I found is to signal the buffer count in the deinit as proposed here: https://developer.apple.com/forums/thread/126781