### PR TITLE
Fixup "Remove shared_ptr from VectorSet, move-almost-only" insertSet

### DIFF
--- a/shared/public/VectorSet.h
+++ b/shared/public/VectorSet.h
@@ -69,8 +69,8 @@ public:
         for (auto it = otherSet.begin(); it != otherSet.end(); it++) {
             // only check if initial set contains a value; 
             // no need to check inserted values also if otherSet is assumed to be duplicate free
-            auto searchEnd = data.end() + oldSize;
-            if(std::find(data.begin(), searchEnd, *it) != searchEnd) {
+            auto searchEnd = data.begin() + oldSize;
+            if(std::find(data.begin(), searchEnd, *it) == searchEnd) {
                 data.push_back(*it);
             }
         }

--- a/shared/test/CMakeLists.txt
+++ b/shared/test/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(tests
   "TestTileSource.cpp"
   "TestGeometryHandler.cpp"
   "TestValueEvaluate.cpp"
+  "TestVectorSet.cpp"
   "helper/TestData.cpp"
 )
 # Use mapscore _private_ include to allow testing functionality declared in internal headers.

--- a/shared/test/TestVectorSet.cpp
+++ b/shared/test/TestVectorSet.cpp
@@ -1,0 +1,25 @@
+#include "VectorSet.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
+
+#include <set>
+
+TEST_CASE("VectorSet<std::string>::insertSet") {
+    VectorSet<std::string> vsA{ "foo", "bar" };
+    VectorSet<std::string> vsB{ "bar", "fnord", "food" };
+    VectorSet<std::string> vsC{ "fnord" };
+    VectorSet<std::string> vsD{ };
+    VectorSet<std::string> vsE{ "napf" };
+    vsA.insertSet(vsB);
+    vsA.insertSet(vsC);
+    vsA.insertSet(vsD);
+    vsA.insertSet(vsE);
+
+    std::set<std::string> setA(vsA.begin(), vsA.end());
+    setA.insert(vsB.begin(), vsB.end());
+    setA.insert(vsC.begin(), vsC.end());
+    setA.insert(vsD.begin(), vsD.end());
+    setA.insert(vsE.begin(), vsE.end());
+    REQUIRE_THAT(vsA, Catch::Matchers::UnorderedRangeEquals(setA));
+}


### PR DESCRIPTION
This fixes a bug introduced in 2ff6320b8d94374b401ef0a46d9dcd1ea5534827.

Fix bad iterator (begin() + size, instead of end() + size) and flipped condition logic error in "optimized" insertSet.

Add a test, like I should have in the first place.