### PR TITLE
Atlas generator Padding

### DIFF
--- a/android/src/main/java/io/openmobilemaps/mapscore/map/util/CustomIconImageProvider.kt
+++ b/android/src/main/java/io/openmobilemaps/mapscore/map/util/CustomIconImageProvider.kt
@@ -29,7 +29,9 @@ class CustomIconImageProvider(
                     (bitmap?.width ?: 1).toInt(),
                     (bitmap?.height ?: 1).toInt()
                 )
-            }), Vec2I(MAX_SIZE_TEXTURE_PAGE_PX, MAX_SIZE_TEXTURE_PAGE_PX)
+            }),
+			Vec2I(MAX_SIZE_TEXTURE_PAGE_PX, MAX_SIZE_TEXTURE_PAGE_PX),
+			1
         )
 
         return ArrayList(packerResult.map { page ->

--- a/android/src/main/java/io/openmobilemaps/mapscore/map/util/TextureAtlasProvider.kt
+++ b/android/src/main/java/io/openmobilemaps/mapscore/map/util/TextureAtlasProvider.kt
@@ -11,12 +11,14 @@ import io.openmobilemaps.mapscore.shared.graphics.common.Vec2I
 object TextureAtlasProvider {
     fun createTextureAtlas(
         bitmaps: Map<String, Bitmap>,
-        maxAtlasSize: Int = 1024
+        maxAtlasSize: Int = 1024,
+		spacing: Int = 1
     ): ArrayList<TextureAtlas> {
         val packerResult = RectanglePacker.pack(
             HashMap(bitmaps.mapValues { (identifier, bitmap) ->
                 Vec2I(bitmap.width, bitmap.height)
-            }), Vec2I(maxAtlasSize, maxAtlasSize)
+            }), Vec2I(maxAtlasSize, maxAtlasSize),
+			spacing
         )
 
         return ArrayList(packerResult.map { page ->

--- a/bridging/android/java/io/openmobilemaps/mapscore/shared/graphics/RectanglePacker.kt
+++ b/bridging/android/java/io/openmobilemaps/mapscore/shared/graphics/RectanglePacker.kt
@@ -10,7 +10,7 @@ abstract class RectanglePacker {
 
     companion object {
         @JvmStatic
-        external fun pack(rectangles: HashMap<String, io.openmobilemaps.mapscore.shared.graphics.common.Vec2I>, maxPageSize: io.openmobilemaps.mapscore.shared.graphics.common.Vec2I): ArrayList<RectanglePackerPage>
+        external fun pack(rectangles: HashMap<String, io.openmobilemaps.mapscore.shared.graphics.common.Vec2I>, maxPageSize: io.openmobilemaps.mapscore.shared.graphics.common.Vec2I, spacing: Int): ArrayList<RectanglePackerPage>
     }
 
     public class CppProxy : RectanglePacker {

--- a/bridging/android/jni/graphics/NativeRectanglePacker.cpp
+++ b/bridging/android/jni/graphics/NativeRectanglePacker.cpp
@@ -20,11 +20,12 @@ CJNIEXPORT void JNICALL Java_io_openmobilemaps_mapscore_shared_graphics_Rectangl
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 
-CJNIEXPORT jobject JNICALL Java_io_openmobilemaps_mapscore_shared_graphics_RectanglePacker_pack(JNIEnv* jniEnv, jobject /*this*/, jobject j_rectangles, ::djinni_generated::NativeVec2I::JniType j_maxPageSize)
+CJNIEXPORT jobject JNICALL Java_io_openmobilemaps_mapscore_shared_graphics_RectanglePacker_pack(JNIEnv* jniEnv, jobject /*this*/, jobject j_rectangles, ::djinni_generated::NativeVec2I::JniType j_maxPageSize, jint j_spacing)
 {
     try {
         auto r = ::RectanglePacker::pack(::djinni::Map<::djinni::String, ::djinni_generated::NativeVec2I>::toCpp(jniEnv, j_rectangles),
-                                         ::djinni_generated::NativeVec2I::toCpp(jniEnv, j_maxPageSize));
+                                         ::djinni_generated::NativeVec2I::toCpp(jniEnv, j_maxPageSize),
+                                         ::djinni::I32::toCpp(jniEnv, j_spacing));
         return ::djinni::release(::djinni::List<::djinni_generated::NativeRectanglePackerPage>::fromCpp(jniEnv, r));
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, 0 /* value doesn't matter */)
 }

--- a/bridging/ios/MCRectanglePacker+Private.mm
+++ b/bridging/ios/MCRectanglePacker+Private.mm
@@ -33,10 +33,12 @@ static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for th
 }
 
 + (nonnull NSArray<MCRectanglePackerPage *> *)pack:(nonnull NSDictionary<NSString *, MCVec2I *> *)rectangles
-                                       maxPageSize:(nonnull MCVec2I *)maxPageSize {
+                                       maxPageSize:(nonnull MCVec2I *)maxPageSize
+                                           spacing:(int32_t)spacing {
     try {
         auto objcpp_result_ = ::RectanglePacker::pack(::djinni::Map<::djinni::String, ::djinni_generated::Vec2I>::toCpp(rectangles),
-                                                      ::djinni_generated::Vec2I::toCpp(maxPageSize));
+                                                      ::djinni_generated::Vec2I::toCpp(maxPageSize),
+                                                      ::djinni::I32::toCpp(spacing));
         return ::djinni::List<::djinni_generated::RectanglePackerPage>::fromCpp(objcpp_result_);
     } DJINNI_TRANSLATE_EXCEPTIONS()
 }

--- a/bridging/ios/MCRectanglePacker.h
+++ b/bridging/ios/MCRectanglePacker.h
@@ -9,6 +9,7 @@
 @interface MCRectanglePacker : NSObject
 
 + (nonnull NSArray<MCRectanglePackerPage *> *)pack:(nonnull NSDictionary<NSString *, MCVec2I *> *)rectangles
-                                       maxPageSize:(nonnull MCVec2I *)maxPageSize;
+                                       maxPageSize:(nonnull MCVec2I *)maxPageSize
+                                           spacing:(int32_t)spacing;
 
 @end

--- a/djinni/graphics/packer.djinni
+++ b/djinni/graphics/packer.djinni
@@ -7,7 +7,7 @@ rectangle_packer_page = record {
 }
 
 rectangle_packer = interface +c {
-    static pack(rectangles: map<string, vec_2_i>, max_page_size: vec_2_i): list<rectangle_packer_page>;
+    static pack(rectangles: map<string, vec_2_i>, max_page_size: vec_2_i, spacing: i32): list<rectangle_packer_page>;
 }
 
 texture_atlas = record {

--- a/ios/graphics/Texture/MCAssetProvider.swift
+++ b/ios/graphics/Texture/MCAssetProvider.swift
@@ -47,7 +47,7 @@ open class MCAssetProvider: MCTiled2dMapVectorLayerSymbolDelegateInterface {
             images[featureInfo.identifier] = getImageFor(for: featureInfo, layerIdentifier: layerIdentifier)
         }
 
-        let packerResult = MCRectanglePacker.pack(images.mapValues { MCVec2I(x: Int32($0.size.width * scale), y: Int32($0.size.height * scale)) }, maxPageSize: MCVec2I(x: 4096, y: 4096))
+        let packerResult = MCRectanglePacker.pack(images.mapValues { MCVec2I(x: Int32($0.size.width * scale), y: Int32($0.size.height * scale)) }, maxPageSize: MCVec2I(x: 4096, y: 4096), spacing: 1)
 
         var results = [MCTiled2dMapVectorAssetInfo]()
 

--- a/ios/helpers/MCTextureAtlasProvider.swift
+++ b/ios/helpers/MCTextureAtlasProvider.swift
@@ -19,13 +19,15 @@ public enum MCTextureAtlasProvider {
 
     public static func createTextureAtlas(
         images: [String: PlatformImage],
-        maxAtlasSize: CGSize = CGSize(width: 4096, height: 4096)
+        maxAtlasSize: CGSize = CGSize(width: 4096, height: 4096),
+        spacing: Int32 = 1
     ) -> [MCTextureAtlas] {
         let packerResult = MCRectanglePacker.pack(
             images.mapValues {
                 MCVec2I(x: Int32($0.size.width), y: Int32($0.size.height))
             },
-            maxPageSize: .init(x: Int32(maxAtlasSize.width), y: Int32(maxAtlasSize.height))
+            maxPageSize: .init(x: Int32(maxAtlasSize.width), y: Int32(maxAtlasSize.height)),
+            spacing: spacing
         )
 
         return packerResult.compactMap { page -> MCTextureAtlas? in
@@ -62,13 +64,13 @@ public enum MCTextureAtlasProvider {
 
             for (key, rect) in uvs {
                 if let image = images[key] {
-                    image.draw(
-                        in: CGRect(
-                            x: CGFloat(rect.x),
-                            y: CGFloat(rect.y),
-                            width: CGFloat(rect.width),
-                            height: CGFloat(rect.height)
-                        ))
+                    let cgRect = CGRect(
+                        x: CGFloat(rect.x),
+                        y: CGFloat(rect.y),
+                        width: CGFloat(rect.width),
+                        height: CGFloat(rect.height)
+                    )
+                    image.draw(in: cgRect)
                 }
             }
 

--- a/shared/public/RectanglePacker.h
+++ b/shared/public/RectanglePacker.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "Vec2I.h"
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -14,5 +15,5 @@ class RectanglePacker {
 public:
     virtual ~RectanglePacker() = default;
 
-    static std::vector<RectanglePackerPage> pack(const std::unordered_map<std::string, ::Vec2I> & rectangles, const ::Vec2I & maxPageSize);
+    static std::vector<RectanglePackerPage> pack(const std::unordered_map<std::string, ::Vec2I> & rectangles, const ::Vec2I & maxPageSize, int32_t spacing);
 };

--- a/shared/src/graphics/packer/RectanglePacker.cpp
+++ b/shared/src/graphics/packer/RectanglePacker.cpp
@@ -16,10 +16,10 @@
 #include <algorithm>
 
 
-std::vector<RectanglePackerPage> RectanglePacker::pack(const std::unordered_map<std::string, ::Vec2I> & rectangles, const ::Vec2I & maxPageSize) {
+std::vector<RectanglePackerPage> RectanglePacker::pack(const std::unordered_map<std::string, ::Vec2I> & rectangles, const ::Vec2I & maxPageSize, int32_t spacing) {
 
     std::unordered_map<size_t, RectanglePackerPage> results;
-    dp::rect_pack::RectPacker packer = dp::rect_pack::RectPacker<int32_t>(maxPageSize.x, maxPageSize.y);
+    dp::rect_pack::RectPacker packer = dp::rect_pack::RectPacker<int32_t>(maxPageSize.x, maxPageSize.y, dp::rect_pack::RectPacker<int32_t>::Spacing(spacing));
 
     std::vector<std::tuple<std::string, ::Vec2I>> sortedRectangles;
 


### PR DESCRIPTION
allow padding to be set for rectangle packing to fix bilinear interpolation near a edge of a texture