### PR TITLE
Bugfix: rotated stretch icon

### DIFF
--- a/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSymbolLabelObject.cpp
+++ b/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSymbolLabelObject.cpp
@@ -648,19 +648,11 @@ void Tiled2dMapVectorSymbolLabelObject::updatePropertiesPoint(VectorModification
         countOffset += 1;
     }
 
-    auto rectBoundingBoxTopLeft = (numberOfCharacters > 0) ? boundingBoxMin :  referencePoint;
-    auto rectBoundingBoxBottomRight = (numberOfCharacters > 0) ? boundingBoxMax :  referencePoint;
-
     const float scaledTextPadding = is3d ? textPadding : scaleFactor * textPadding;
 
-    rectBoundingBoxTopLeft.x -= scaledTextPadding;
-    rectBoundingBoxTopLeft.y -= scaledTextPadding;
-
-    rectBoundingBoxBottomRight.x += scaledTextPadding;
-    rectBoundingBoxBottomRight.y += scaledTextPadding;
-
-    dimensions.x = rectBoundingBoxBottomRight.x - rectBoundingBoxTopLeft.x;
-    dimensions.y = rectBoundingBoxBottomRight.y - rectBoundingBoxTopLeft.y;
+    // dimensions before rotation, with padding included
+    dimensions.x = size.x + 2 * scaledTextPadding;
+    dimensions.y = size.y + 2 * scaledTextPadding;
 
     if (rotationAlignment != SymbolAlignment::MAP) {
         if (is3d) {


### PR DESCRIPTION
- [use unrotated box for dimension calculation](https://github.com/openmobilemaps/maps-core/commit/9c4862d35e0c513b801e72ffcac9fec32b9db9f2)

![image](https://github.com/user-attachments/assets/cc60a219-9958-49c8-b7a2-7fe858057512)
