### PR TITLE
optimize rendering by moving hidden labels offscreen to skip unnecessary fragment shading

### DIFF
--- a/ios/graphics/Shader/Metal/TextInstancedShader.metal
+++ b/ios/graphics/Shader/Metal/TextInstancedShader.metal
@@ -36,6 +36,14 @@ unitSphereTextInstancedVertexShader(const VertexIn vertexIn [[stage_in]],
                           constant float *alphas [[buffer(12)]],
                           uint instanceId [[instance_id]])
 {
+    float alpha = alphas[instanceId];
+
+    if (alpha == 0) {
+        return TextInstancedVertexOut {
+            .position = float4(-3,-3,-3,-3)
+        };
+    }
+
     const float3 referencePosition = referencePositions[instanceId];
     const float2 offset = positions[instanceId];
     const float2 scale = scales[instanceId];
@@ -55,10 +63,10 @@ unitSphereTextInstancedVertexShader(const VertexIn vertexIn [[stage_in]],
 
     auto diffCenter = screenPosition - earthCenter;
 
-    float alpha = alphas[instanceId];
-
     if (diffCenter.z > 0) {
-        alpha = 0.0;
+        return TextInstancedVertexOut {
+            .position = float4(-3,-3,-3,-3)
+        };
     }
 
     const float sinAngle = sin(angle);
@@ -72,10 +80,6 @@ unitSphereTextInstancedVertexShader(const VertexIn vertexIn [[stage_in]],
                        (pScaled.x * sinAngle + pScaled.y * cosAngle) * aspectRatio);
 
     auto position = float4(screenPosition.xy + offset.xy + pRot, 0.0, 1.0);
-
-    if (alpha == 0) {
-        position = float4(-3,-3,-3,-3);
-    }
 
     TextInstancedVertexOut out {
       .position = position,

--- a/ios/graphics/Shader/Metal/TextInstancedShader.metal
+++ b/ios/graphics/Shader/Metal/TextInstancedShader.metal
@@ -61,17 +61,21 @@ unitSphereTextInstancedVertexShader(const VertexIn vertexIn [[stage_in]],
         alpha = 0.0;
     }
 
-    float sinAngle = sin(angle);
-    float cosAngle = cos(angle);
+    const float sinAngle = sin(angle);
+    const float cosAngle = cos(angle);
 
     const float2 p = (vertexIn.position.xy);
 
     // apply scale, then rotation and aspect ratio correction
-    auto pScaled = float2(p.x * scale.x, p.y * scale.y);
-    auto pRot = float2((pScaled.x * cosAngle - pScaled.y * sinAngle),
+    const auto pScaled = float2(p.x * scale.x, p.y * scale.y);
+    const auto pRot = float2((pScaled.x * cosAngle - pScaled.y * sinAngle),
                        (pScaled.x * sinAngle + pScaled.y * cosAngle) * aspectRatio);
 
     auto position = float4(screenPosition.xy + offset.xy + pRot, 0.0, 1.0);
+
+    if (alpha == 0) {
+        position = float4(-3,-3,-3,-3);
+    }
 
     TextInstancedVertexOut out {
       .position = position,


### PR DESCRIPTION
before:
<img width="421" alt="image" src="https://github.com/user-attachments/assets/abf1324c-3a7c-4562-84c1-b7b17cb628a1" />

after:
<img width="457" alt="image" src="https://github.com/user-attachments/assets/3ffd0d17-16cf-40ff-8f16-1d5b3ef5fc8f" />
