### PR TITLE
Performance improvements

### DIFF
--- a/ios/graphics/RenderingContext.swift
+++ b/ios/graphics/RenderingContext.swift
@@ -88,9 +88,10 @@ public class RenderingContext: NSObject, @unchecked Sendable {
     open func setRenderPipelineStateIfNeeded(
         _ pipelineState: MTLRenderPipelineState
     ) {
-        guard currentPipeline?.hash != pipelineState.hash else {
+        guard currentPipeline !== pipelineState else {
             return
         }
+        
         currentPipeline = pipelineState
         encoder?.setRenderPipelineState(pipelineState)
     }

--- a/ios/graphics/Shader/BaseShader.swift
+++ b/ios/graphics/Shader/BaseShader.swift
@@ -51,7 +51,6 @@ open class BaseShader: MCShaderProgramInterface, @unchecked Sendable {
             guard newBlendMode != self.blendMode else { return }
             self.blendMode = newBlendMode
             self.pipeline = nil
-            self.setupProgram(nil)
         }
 
         if Thread.isMainThread {


### PR DESCRIPTION
- Hash and !== are the same for MTLPipelineRenderState
- setupProgram is done before rendering anyway, if object does not come to this phase, it is done for nothing...