### PR TITLE
Fixed icon touch area check

### DIFF
--- a/shared/src/map/layers/icon/IconLayer.cpp
+++ b/shared/src/map/layers/icon/IconLayer.cpp
@@ -652,6 +652,6 @@ void IconLayer::addScaleAnimation(const IconScaleAnimation& iconScaleAnimation) 
 }
 
 bool IconLayer::isPointInRect(const Vec2F& point, float leftW, float rightW, float topH, float bottomH) {
-    return point.x >  -leftW && point.x < rightW &&
-           point.y > -topH && point.y < bottomH;
+    return point.x > -leftW && point.x < rightW &&
+           point.y < topH && point.y > -bottomH;
 }


### PR DESCRIPTION
Fixed a mismatch between an icon touch area and its displayed image.
[Related issue](https://github.com/geoadmin/lib-open-swiss-maps-sdk/issues/185)