### PR TITLE
Adds filter caching

### DIFF
--- a/shared/public/Value.h
+++ b/shared/public/Value.h
@@ -111,18 +111,21 @@ public:
 public:
     uint64_t identifier;
     vtzero::GeomType geomType;
+    bool hasCustomId = false;
 
     FeatureContext() {}
 
     FeatureContext(const FeatureContext &other)
         : propertiesMap(other.propertiesMap)
         , geomType(other.geomType)
-        , identifier(other.identifier) {}
+        , identifier(other.identifier)
+        , hasCustomId(other.hasCustomId) {}
 
     FeatureContext(FeatureContext &&other)
         : propertiesMap(std::move(other.propertiesMap))
         , geomType(other.geomType)
-        , identifier(other.identifier) {}
+        , identifier(other.identifier)
+        , hasCustomId(other.hasCustomId) {}
 
     FeatureContext(vtzero::GeomType geomType,
                    mapType propertiesMap,
@@ -143,6 +146,7 @@ public:
         size_t hash = 0;
         std::hash_combine(hash, std::hash<std::string>{}(stringIdentifier));
         identifier = hash;
+        hasCustomId = true;
 
         initialize();
     }
@@ -161,6 +165,7 @@ public:
 
         if (feature.has_id()) {
             identifier = feature.id();
+            hasCustomId = true;
         } else {
             size_t hash = 0;
             for(auto const &[key, val]: propertiesMap) {

--- a/shared/public/Value.h
+++ b/shared/public/Value.h
@@ -133,6 +133,7 @@ public:
         : propertiesMap(std::move(propertiesMap))
         , geomType(geomType)
         , identifier(identifier)
+        , hasCustomId(true)
     {
         initialize();
     }

--- a/shared/src/map/layers/tiled/vector/tiles/polygon/Tiled2dMapVectorPolygonPatternTile.cpp
+++ b/shared/src/map/layers/tiled/vector/tiles/polygon/Tiled2dMapVectorPolygonPatternTile.cpp
@@ -187,6 +187,8 @@ void Tiled2dMapVectorPolygonPatternTile::setVectorTileData(const Tiled2dMapVecto
         std::vector<std::vector<ObjectDescriptions>> styleGroupNewPolygonsVector;
         std::unordered_map<int, int32_t> styleIndicesOffsets;
 
+        std::unordered_map<size_t, bool> filterCache;
+        
         std::int32_t indices_offset = 0;
 
         for (auto featureIt = tileData->begin(); featureIt != tileData->end(); featureIt++) {
@@ -196,7 +198,25 @@ void Tiled2dMapVectorPolygonPatternTile::setVectorTileData(const Tiled2dMapVecto
             if (featureContext->geomType != vtzero::GeomType::POLYGON) { continue; }
 
             EvaluationContext evalContext = EvaluationContext(tileInfo.tileInfo.zoomIdentifier, dpFactor, featureContext, featureStateManager);
-            if (description->filter == nullptr || description->filter->evaluateOr(evalContext, false)) {
+
+            bool inside = true;
+            if (description->filter) {
+                if (featureContext->hasCustomId) {
+                    // Every ID is unique → no cache possible
+                    inside = description->filter->evaluateOr(evalContext, false);
+                } else {
+                    auto hash = featureContext->identifier;
+                    auto it = filterCache.find(hash);
+                    if (it != filterCache.end()) {
+                        inside = it->second;
+                    } else {
+                        inside = description->filter->evaluateOr(evalContext, false);
+                        filterCache[hash] = inside;
+                    }
+                }
+            }
+
+            if (inside) {
 
                 std::vector<Coord> positions;
 


### PR DESCRIPTION
For polygon, line, polygon pattern the filter is potentially used across a big number of features, however often the identifiers are the same for these geometries.

It's better to cache them then to reevaluate every time.