### PR TITLE
Fix reference to moved StringInterner kept in GeoJsonVT

### DIFF
--- a/shared/public/Tiled2dMapVectorLayer.h
+++ b/shared/public/Tiled2dMapVectorLayer.h
@@ -75,7 +75,7 @@ class Tiled2dMapVectorLayer : public Tiled2dMapLayer,
 
     Tiled2dMapVectorLayer(const std::string &layerName,
                           const std::shared_ptr<VectorMapDescription> & mapDescription,
-                          StringInterner &&stringTable,
+                          const std::shared_ptr<StringInterner> &stringTable,
                           const std::vector<std::shared_ptr<::LoaderInterface>> & loaders,
                           const std::shared_ptr<::FontLoaderInterface> & fontLoader,
                           const std::optional<Tiled2dMapZoomInfo> &customZoomInfo = std::nullopt,
@@ -211,8 +211,8 @@ class Tiled2dMapVectorLayer : public Tiled2dMapLayer,
 
     virtual void setReadyStateListener(const /*not-null*/ std::shared_ptr<::Tiled2dMapReadyStateListener> &listener) override;
 
-    StringInterner& getStringInterner() { return stringTable; }
-    const StringInterner& getStringInterner() const { return stringTable; }
+    StringInterner& getStringInterner() { return *stringTable; }
+    const StringInterner& getStringInterner() const { return *stringTable; }
 
 	protected:
     virtual void setMapDescription(const std::shared_ptr<VectorMapDescription> &mapDescription);
@@ -231,7 +231,7 @@ class Tiled2dMapVectorLayer : public Tiled2dMapLayer,
     std::vector<Actor<Tiled2dMapRasterSource>> rasterTileSources;
 
     const std::vector<std::shared_ptr<::LoaderInterface>> loaders;
-    StringInterner stringTable;
+    std::shared_ptr<StringInterner> stringTable;
 
     virtual std::optional<TiledLayerError> loadStyleJson();
     virtual std::optional<TiledLayerError> loadStyleJsonRemotely();

--- a/shared/public/Tiled2dMapVectorLayerParserHelper.h
+++ b/shared/public/Tiled2dMapVectorLayerParserHelper.h
@@ -23,14 +23,14 @@ public:
                                                                    const std::string &styleJsonUrl,
                                                                    const std::shared_ptr<Tiled2dMapVectorLayerLocalDataProviderInterface> &localDataProvider,
                                                                    const std::vector<std::shared_ptr<::LoaderInterface>> &loaders, 
-                                                                   StringInterner &stringTable,
+                                                                   const std::shared_ptr<StringInterner> &stringTable,
                                                                    const std::unordered_map<std::string, std::string> & sourceUrlParams);
 
     static Tiled2dMapVectorLayerParserResult parseStyleJsonFromString(const std::string &layerName,
                                                                       const std::string &styleJsonString,
                                                                       const std::shared_ptr<Tiled2dMapVectorLayerLocalDataProviderInterface> &localDataProvider,
                                                                       const std::vector<std::shared_ptr<::LoaderInterface>> &loaders, 
-                                                                      StringInterner &stringTable,
+                                                                      const std::shared_ptr<StringInterner> &stringTable,
                                                                       const std::unordered_map<std::string, std::string> & sourceUrlParams);
 
     static std::string replaceUrlParams(const std::string & url, const std::unordered_map<std::string, std::string> & sourceUrlParams);

--- a/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayer.cpp
+++ b/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayer.cpp
@@ -62,9 +62,9 @@ Tiled2dMapVectorLayer::Tiled2dMapVectorLayer(const std::string &layerName,
         remoteStyleJsonUrl(remoteStyleJsonUrl),
         loaders(loaders),
         fontLoader(fontLoader),
-        stringTable(ValueKeys::newStringInterner()),
+        stringTable(std::make_shared<StringInterner>(ValueKeys::newStringInterner())),
         customZoomInfo(customZoomInfo),
-        featureStateManager(std::make_shared<Tiled2dMapVectorStateManager>(stringTable)),
+        featureStateManager(std::make_shared<Tiled2dMapVectorStateManager>(*stringTable)),
         symbolDelegate(symbolDelegate),
         sourceUrlParams(sourceUrlParams),
         localDataProvider(localDataProvider)
@@ -85,9 +85,9 @@ Tiled2dMapVectorLayer::Tiled2dMapVectorLayer(const std::string &layerName,
         fallbackStyleJsonString(fallbackStyleJsonString),
         loaders(loaders),
         fontLoader(fontLoader),
-        stringTable(ValueKeys::newStringInterner()),
+        stringTable(std::make_shared<StringInterner>(ValueKeys::newStringInterner())),
         customZoomInfo(customZoomInfo),
-        featureStateManager(std::make_shared<Tiled2dMapVectorStateManager>(stringTable)),
+        featureStateManager(std::make_shared<Tiled2dMapVectorStateManager>(*stringTable)),
         symbolDelegate(symbolDelegate),
         sourceUrlParams(sourceUrlParams),
         localDataProvider(localDataProvider)
@@ -96,7 +96,7 @@ Tiled2dMapVectorLayer::Tiled2dMapVectorLayer(const std::string &layerName,
 
 Tiled2dMapVectorLayer::Tiled2dMapVectorLayer(const std::string &layerName,
                                              const std::shared_ptr<VectorMapDescription> &mapDescription,
-                                             StringInterner &&stringTable_,
+                                             const std::shared_ptr<StringInterner> &stringTable,
                                              const std::vector<std::shared_ptr<::LoaderInterface>> &loaders,
                                              const std::shared_ptr<::FontLoaderInterface> &fontLoader,
                                              const std::optional<Tiled2dMapZoomInfo> &customZoomInfo,
@@ -108,9 +108,9 @@ Tiled2dMapVectorLayer::Tiled2dMapVectorLayer(const std::string &layerName,
         layerName(layerName),
         loaders(loaders),
         fontLoader(fontLoader),
-        stringTable(std::move(stringTable_)),
+        stringTable(stringTable),
         customZoomInfo(customZoomInfo),
-        featureStateManager(std::make_shared<Tiled2dMapVectorStateManager>(stringTable)),
+        featureStateManager(std::make_shared<Tiled2dMapVectorStateManager>(*stringTable)),
         symbolDelegate(symbolDelegate),
         localDataProvider(localDataProvider),
 		sourceUrlParams(sourceUrlParams),
@@ -128,9 +128,9 @@ Tiled2dMapVectorLayer::Tiled2dMapVectorLayer(const std::string &layerName,
         layerName(layerName),
         loaders(loaders),
         fontLoader(fontLoader),
-        stringTable(ValueKeys::newStringInterner()),
+        stringTable(std::make_shared<StringInterner>(ValueKeys::newStringInterner())),
         customZoomInfo(customZoomInfo),
-        featureStateManager(std::make_shared<Tiled2dMapVectorStateManager>(stringTable)),
+        featureStateManager(std::make_shared<Tiled2dMapVectorStateManager>(*stringTable)),
         symbolDelegate(symbolDelegate),
         sourceUrlParams(sourceUrlParams)
         {}
@@ -585,7 +585,7 @@ void Tiled2dMapVectorLayer::reloadLocalDataSource(const std::string &sourceName,
 
         try {
             auto json = nlohmann::json::parse(geoJson);
-            geoSource->reload(GeoJsonParser::getGeoJson(json, stringTable));
+            geoSource->reload(GeoJsonParser::getGeoJson(json, *stringTable));
         }
         catch (nlohmann::json::exception &ex) {
             return;
@@ -1492,7 +1492,7 @@ std::vector<VectorLayerFeatureCoordInfo> Tiled2dMapVectorLayer::getVisiblePointF
                             bool isVisible = camera->coordIsVisibleOnScreen(coord, paddingPc);
 
                             if (isVisible) {
-                                features.push_back(VectorLayerFeatureCoordInfo(featureContext->getFeatureInfo(stringTable), coord));
+                                features.push_back(VectorLayerFeatureCoordInfo(featureContext->getFeatureInfo(*stringTable), coord));
                             }
                         }
                     }

--- a/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayerInterface.cpp
+++ b/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayerInterface.cpp
@@ -37,7 +37,7 @@ Tiled2dMapVectorLayerInterface::createExplicitly(const std::string &layerName,
 
     if ((localStyleJson.has_value() && *localStyleJson) || localDataProvider) {
         std::optional<Tiled2dMapVectorLayerParserResult> parserResult = std::nullopt;
-        StringInterner stringTable = ValueKeys::newStringInterner();
+        std::shared_ptr<StringInterner> stringTable = std::make_shared<StringInterner>(ValueKeys::newStringInterner());
 
         if (localDataProvider) {
             auto localProvidedStyleJson = localDataProvider->getStyleJson();

--- a/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayerParserHelper.cpp
+++ b/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayerParserHelper.cpp
@@ -33,7 +33,7 @@ Tiled2dMapVectorLayerParserResult Tiled2dMapVectorLayerParserHelper::parseStyleJ
                                                         const std::string &styleJsonUrl,
                                                         const std::shared_ptr<Tiled2dMapVectorLayerLocalDataProviderInterface> &localDataProvider,
                                                         const std::vector<std::shared_ptr<::LoaderInterface>> &loaders,
-                                                        StringInterner &stringTable,
+                                                        const std::shared_ptr<StringInterner> &stringTable,
                                                         const std::unordered_map<std::string, std::string> & sourceUrlParams) {
     DataLoaderResult result = LoaderHelper::loadData(styleJsonUrl, std::nullopt, loaders);
     if (result.status != LoaderStatus::OK) {
@@ -59,7 +59,7 @@ Tiled2dMapVectorLayerParserResult Tiled2dMapVectorLayerParserHelper::parseStyleJ
                                                         const std::string &styleJsonString,
                                                         const std::shared_ptr<Tiled2dMapVectorLayerLocalDataProviderInterface> &localDataProvider,
                                                         const std::vector<std::shared_ptr<::LoaderInterface>> &loaders,
-                                                        StringInterner &stringTable,
+                                                        const std::shared_ptr<StringInterner> &stringTable,
                                                         const std::unordered_map<std::string, std::string> & sourceUrlParams) {
 
     nlohmann::json json;
@@ -229,7 +229,7 @@ Tiled2dMapVectorLayerParserResult Tiled2dMapVectorLayerParserHelper::parseStyleJ
                 geojsonSources[key] = GeoJsonVTFactory::getGeoJsonVt(key, replaceUrlParams(val["data"].get<std::string>(), sourceUrlParams), loaders, localDataProvider, stringTable, options);
             } else {
                 try {
-                    geojsonSources[key] = GeoJsonVTFactory::getGeoJsonVt(GeoJsonParser::getGeoJson(val["data"], stringTable), stringTable, options);
+                    geojsonSources[key] = GeoJsonVTFactory::getGeoJsonVt(GeoJsonParser::getGeoJson(val["data"], *stringTable), stringTable, options);
                 }
                 catch (nlohmann::json::exception &ex) {
                     return Tiled2dMapVectorLayerParserResult(nullptr, LoaderStatus::ERROR_OTHER, ex.what(), std::nullopt);
@@ -291,7 +291,7 @@ Tiled2dMapVectorLayerParserResult Tiled2dMapVectorLayerParserHelper::parseStyleJ
     }
 
 
-    Tiled2dMapVectorStyleParser parser(stringTable);
+    Tiled2dMapVectorStyleParser parser(*stringTable);
 
     std::optional<std::string> metadata;
     std::shared_ptr<Value> globalIsInteractable;

--- a/shared/src/map/layers/tiled/vector/geojson/GeoJsonVTFactory.h
+++ b/shared/src/map/layers/tiled/vector/geojson/GeoJsonVTFactory.h
@@ -13,14 +13,10 @@
 #include "GeoJsonTypes.h"
 #include "Tiled2dMapVectorLayerLocalDataProviderInterface.h"
 
-#include "json.h"
-
-#include <random>
-
 class GeoJsonVTFactory {
 public:
     static std::shared_ptr<GeoJSONVTInterface> getGeoJsonVt(const std::shared_ptr<GeoJson> &geoJson,
-                                                            StringInterner &stringTable,
+                                                            const std::shared_ptr<StringInterner> &stringTable,
                                                             const Options& options = Options()) {
         return std::static_pointer_cast<GeoJSONVTInterface>(std::make_shared<GeoJSONVT>(geoJson, stringTable, options));
     }
@@ -28,7 +24,7 @@ public:
     static std::shared_ptr<GeoJSONVTInterface> getGeoJsonVt(const std::string &sourceName,
                                                             const std::string &geoJsonUrl,
                                                             const std::vector<std::shared_ptr<::LoaderInterface>> &loaders, const std::shared_ptr<Tiled2dMapVectorLayerLocalDataProviderInterface> &localDataProvider,
-                                                            StringInterner &stringTable,
+                                                            const std::shared_ptr<StringInterner> &stringTable,
                                                             const Options& options = Options()) {
         std::shared_ptr<GeoJSONVT> vt = std::make_shared<GeoJSONVT>(sourceName, geoJsonUrl, loaders, localDataProvider, stringTable, options);
         vt->load();

--- a/shared/test/TestStyleParser.cpp
+++ b/shared/test/TestStyleParser.cpp
@@ -27,7 +27,7 @@ public:
 
 TEST_CASE("TestStyleParser", "[GeoJson inline]") {
     auto jsonString = TestData::readFileToString("style/geojson_style_inline.json");
-    StringInterner stringTable = ValueKeys::newStringInterner();
+    std::shared_ptr<StringInterner> stringTable = std::make_shared<StringInterner>(ValueKeys::newStringInterner());
     auto result = Tiled2dMapVectorLayerParserHelper::parseStyleJsonFromString("test", jsonString, nullptr, {}, stringTable, {});
     REQUIRE(result.mapDescription != nullptr);
     REQUIRE(!result.mapDescription->geoJsonSources.empty());
@@ -47,7 +47,7 @@ TEST_CASE("TestStyleParser", "[GeoJson local provider]") {
     auto provider = std::make_shared<TestLocalDataProvider>(std::unordered_map<std::string, std::string>{
         {"wsource", "geojson.geojson"}
     });
-    StringInterner stringTable = ValueKeys::newStringInterner();
+    std::shared_ptr<StringInterner> stringTable = std::make_shared<StringInterner>(ValueKeys::newStringInterner());
     auto result = Tiled2dMapVectorLayerParserHelper::parseStyleJsonFromString("test", jsonString, provider, {}, stringTable, {});
     REQUIRE(result.mapDescription != nullptr);
     REQUIRE(!result.mapDescription->geoJsonSources.empty());


### PR DESCRIPTION
GeoJsonVT was constructed with a reference to a StringInterner (on the stack). Later the StringInterner was moved into the vector layer object, with the inteded lifetime of the string table.
Keep the StringInterner in a shared_ptr instead, oh well.