### PR TITLE
Enable -Wunused and fix warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,9 +27,6 @@ add_library(mapscore STATIC ${mapscore_SRC})
 find_package(OpenGL)
 
 target_include_directories(mapscore PRIVATE
-  external/protozero/protozero/include/
-  external/vtzero/vtzero/include/
-  external/earcut/earcut/include/mapbox/
   shared/src
   shared/src/external/pugixml
   shared/src/external/gpc
@@ -69,6 +66,11 @@ target_include_directories(mapscore PRIVATE
   shared/src/map/scheduling
   shared/src/utils
 )
+target_include_directories(mapscore SYSTEM PRIVATE
+  external/earcut/earcut/include/mapbox/
+  external/protozero/protozero/include/
+  external/vtzero/vtzero/include/
+)
 
 if(NOT APPLE)
   target_include_directories(mapscore PRIVATE
@@ -82,6 +84,8 @@ endif()
 
 target_include_directories(mapscore PUBLIC
   shared/public
+)
+target_include_directories(mapscore SYSTEM PUBLIC
   external/djinni/support-lib/
   external/djinni/support-lib/cpp
 )
@@ -100,7 +104,9 @@ else()
 endif()
 
 target_compile_features(mapscore PRIVATE cxx_std_20)
-target_compile_options(mapscore PRIVATE -Werror -Wno-deprecated -Wno-reorder -fPIC) # fPIC so we can "embed" into shared mapscore_jni
+# -Wmno-deprecated-declarations: djinni uses some deprecated functions in its cpp support library headers. 
+#   Clang thinks that its important enough to warn about (certain) deprecations even in system headers.
+target_compile_options(mapscore PRIVATE -Werror -Wunused -Wno-deprecated-declarations -Wno-reorder -fPIC) # fPIC so we can "embed" into shared mapscore_jni
 target_link_libraries(mapscore ${OPENGL_LIBRARIES})
 
 add_subdirectory(shared/test)

--- a/Package.swift
+++ b/Package.swift
@@ -182,6 +182,11 @@ let package = Package(
                 .headerSearchPath("src/utils"),
                 .define("DEBUG", to: "1", .when(configuration: .debug)),
                 .define("NDEBUG", to: "1", .when(configuration: .release)),
+                // Warnings, needs Swift 6.2:
+                // .treatAllWarnings(as: .error),
+                // .enableWarning("unused"),
+                // .disableWarning("deprecated-declarations"),
+                // .disableWarning("reorder"),
             ]
         ),
     ],

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -4,6 +4,9 @@
 # Sets the minimum version of CMake required to build the native library.
 
 cmake_minimum_required(VERSION 3.4.1)
+project(mapscore_android
+  LANGUAGES CXX
+)
 
 # Creates and names a library, sets it as either STATIC
 # or SHARED, and provides the relative paths to its source code.
@@ -33,83 +36,102 @@ add_library( # Sets the name of the library.
 
         ${cpp_SRC})
 
-include_directories(../external/djinni/support-lib/)
-include_directories(../external/djinni/support-lib/cpp)
-include_directories(../external/djinni/support-lib/jni)
-include_directories(../external/protozero/protozero/include/)
-include_directories(../external/vtzero/vtzero/include/)
-include_directories(../external/earcut/earcut/include/mapbox/)
-include_directories(../bridging/android/jni/graphics)
-include_directories(../bridging/android/jni/graphics/common)
-include_directories(../bridging/android/jni/graphics/objects)
-include_directories(../bridging/android/jni/graphics/shader)
-include_directories(../bridging/android/jni/map)
-include_directories(../bridging/android/jni/map/controls)
-include_directories(../bridging/android/jni/map/layers)
-include_directories(../bridging/android/jni/map/layers/effect)
-include_directories(../bridging/android/jni/map/layers/icon)
-include_directories(../bridging/android/jni/map/layers/line)
-include_directories(../bridging/android/jni/map/layers/objects)
-include_directories(../bridging/android/jni/map/layers/polygon)
-include_directories(../bridging/android/jni/map/layers/skysphere)
-include_directories(../bridging/android/jni/map/layers/text)
-include_directories(../bridging/android/jni/map/layers/tiled)
-include_directories(../bridging/android/jni/map/layers/tiled/raster)
-include_directories(../bridging/android/jni/map/layers/tiled/vector)
-include_directories(../bridging/android/jni/map/loader)
-include_directories(../bridging/android/jni/map/scheduling)
-include_directories(../bridging/android/jni/map/coordinates)
-include_directories(../bridging/android/jni/map/camera)
-include_directories(../bridging/android/jni/utils)
-include_directories(../shared/public)
-include_directories(../shared/src)
-include_directories(../shared/src/external/pugixml)
-include_directories(../shared/src/external/gpc)
-include_directories(../shared/src/logger)
-include_directories(../shared/src/graphics)
-include_directories(../shared/src/graphics/helpers)
-include_directories(../shared/src/map)
-include_directories(../shared/src/map/camera)
-include_directories(../shared/src/map/controls)
-include_directories(../shared/src/map/coordinates)
-include_directories(../shared/src/map/layers)
-include_directories(../shared/src/map/layers/effect)
-include_directories(../shared/src/map/layers/icon)
-include_directories(../shared/src/map/layers/objects)
-include_directories(../shared/src/map/layers/polygon)
-include_directories(../shared/src/map/layers/line)
-include_directories(../shared/src/map/layers/skysphere)
-include_directories(../shared/src/map/layers/text)
-include_directories(../shared/src/map/layers/tiled)
-include_directories(../shared/src/map/layers/tiled/raster)
-include_directories(../shared/src/map/layers/tiled/wmts)
-include_directories(../shared/src/map/layers/tiled/vector)
-include_directories(../shared/src/map/layers/tiled/vector/geojson)
-include_directories(../shared/src/map/layers/tiled/vector/geojson/geojsonvt)
-include_directories(../shared/src/map/layers/tiled/vector/tiles)
-include_directories(../shared/src/map/layers/tiled/vector/tiles/raster)
-include_directories(../shared/src/map/layers/tiled/vector/tiles/polygon)
-include_directories(../shared/src/map/layers/tiled/vector/tiles/line)
-include_directories(../shared/src/map/layers/tiled/vector/sourcemanagers)
-include_directories(../shared/src/map/layers/tiled/vector/sublayers)
-include_directories(../shared/src/map/layers/tiled/vector/sublayers/raster)
-include_directories(../shared/src/map/layers/tiled/vector/sublayers/line)
-include_directories(../shared/src/map/layers/tiled/vector/sublayers/polygon)
-include_directories(../shared/src/map/layers/tiled/vector/sublayers/symbol)
-include_directories(../shared/src/map/layers/tiled/vector/sublayers/background)
-include_directories(../shared/src/map/layers/tiled/vector/symbol)
-include_directories(../shared/src/map/layers/tiled/vector/description)
-include_directories(../shared/src/map/layers/tiled/vector/parsing)
-include_directories(../shared/src/map/scheduling)
-include_directories(../shared/src/utils)
-include_directories(src/main/cpp)
-include_directories(src/main/cpp/graphics)
-include_directories(src/main/cpp/graphics/objects)
-include_directories(src/main/cpp/graphics/shader)
-include_directories(src/main/cpp/utils)
-include_directories(src/main/cpp/scheduling)
+target_include_directories(mapscore SYSTEM PRIVATE
+        ../external/djinni/support-lib/jni
+        ../external/protozero/protozero/include/
+        ../external/vtzero/vtzero/include/
+        ../external/earcut/earcut/include/mapbox/
+)
+target_include_directories(mapscore PRIVATE
+        ../bridging/android/jni/graphics
+        ../bridging/android/jni/graphics/common
+        ../bridging/android/jni/graphics/objects
+        ../bridging/android/jni/graphics/shader
+        ../bridging/android/jni/map
+        ../bridging/android/jni/map/controls
+        ../bridging/android/jni/map/layers
+        ../bridging/android/jni/map/layers/effect
+        ../bridging/android/jni/map/layers/icon
+        ../bridging/android/jni/map/layers/line
+        ../bridging/android/jni/map/layers/objects
+        ../bridging/android/jni/map/layers/polygon
+        ../bridging/android/jni/map/layers/skysphere
+        ../bridging/android/jni/map/layers/text
+        ../bridging/android/jni/map/layers/tiled
+        ../bridging/android/jni/map/layers/tiled/raster
+        ../bridging/android/jni/map/layers/tiled/vector
+        ../bridging/android/jni/map/loader
+        ../bridging/android/jni/map/scheduling
+        ../bridging/android/jni/map/coordinates
+        ../bridging/android/jni/map/camera
+        ../bridging/android/jni/utils
+        ../shared/src
+        ../shared/src/external/pugixml
+        ../shared/src/external/gpc
+        ../shared/src/logger
+        ../shared/src/graphics
+        ../shared/src/graphics/helpers
+        ../shared/src/map
+        ../shared/src/map/camera
+        ../shared/src/map/controls
+        ../shared/src/map/coordinates
+        ../shared/src/map/layers
+        ../shared/src/map/layers/effect
+        ../shared/src/map/layers/icon
+        ../shared/src/map/layers/objects
+        ../shared/src/map/layers/polygon
+        ../shared/src/map/layers/line
+        ../shared/src/map/layers/skysphere
+        ../shared/src/map/layers/text
+        ../shared/src/map/layers/tiled
+        ../shared/src/map/layers/tiled/raster
+        ../shared/src/map/layers/tiled/wmts
+        ../shared/src/map/layers/tiled/vector
+        ../shared/src/map/layers/tiled/vector/geojson
+        ../shared/src/map/layers/tiled/vector/geojson/geojsonvt
+        ../shared/src/map/layers/tiled/vector/tiles
+        ../shared/src/map/layers/tiled/vector/tiles/raster
+        ../shared/src/map/layers/tiled/vector/tiles/polygon
+        ../shared/src/map/layers/tiled/vector/tiles/line
+        ../shared/src/map/layers/tiled/vector/sourcemanagers
+        ../shared/src/map/layers/tiled/vector/sublayers
+        ../shared/src/map/layers/tiled/vector/sublayers/raster
+        ../shared/src/map/layers/tiled/vector/sublayers/line
+        ../shared/src/map/layers/tiled/vector/sublayers/polygon
+        ../shared/src/map/layers/tiled/vector/sublayers/symbol
+        ../shared/src/map/layers/tiled/vector/sublayers/background
+        ../shared/src/map/layers/tiled/vector/symbol
+        ../shared/src/map/layers/tiled/vector/description
+        ../shared/src/map/layers/tiled/vector/parsing
+        ../shared/src/map/scheduling
+        ../shared/src/utils
+        src/main/cpp
+        src/main/cpp/graphics
+        src/main/cpp/graphics/objects
+        src/main/cpp/graphics/shader
+        src/main/cpp/utils
+        src/main/cpp/scheduling
+)
+target_include_directories(mapscore PUBLIC
+        ../shared/public
+)
+target_include_directories(mapscore SYSTEM PUBLIC
+        ../shared/public
+        ../external/djinni/support-lib/
+        ../external/djinni/support-lib/cpp
+)
 
 target_compile_definitions(mapscore PRIVATE OPENMOBILEMAPS_GL=1)
+target_compile_options(mapscore PRIVATE -Werror -Wunused -Wno-reorder)
+
+# Disable warnings in djinni support lib
+set_property(
+  SOURCE ../external/djinni/support-lib/jni/djinni_support.cpp
+  APPEND
+  PROPERTY COMPILE_OPTIONS
+  -Wno-deprecated)
+
+
 
 # Searches for a specified prebuilt library and stores the path as a
 # variable. Because CMake includes system libraries in the search path by

--- a/android/src/main/cpp/graphics/OpenGlContext.cpp
+++ b/android/src/main/cpp/graphics/OpenGlContext.cpp
@@ -8,6 +8,7 @@
  *  SPDX-License-Identifier: MPL-2.0
  */
 
+#include "ChronoUtil.h"
 #include "OpenGlContext.h"
 #include "OpenGlRenderTarget.h"
 #include "BaseShaderProgramOpenGl.h"

--- a/android/src/main/cpp/graphics/OpenGlContext.h
+++ b/android/src/main/cpp/graphics/OpenGlContext.h
@@ -14,7 +14,7 @@
 #include "OpenGlRenderTargetInterface.h"
 #include "RenderingContextInterface.h"
 #include "RenderingCullMode.h"
-#include "ChronoUtil.h"
+#include <chrono>
 #include <opengl_wrapper.h>
 #include <memory>
 #include <string>

--- a/android/src/main/cpp/graphics/shader/AlphaShaderOpenGl.cpp
+++ b/android/src/main/cpp/graphics/shader/AlphaShaderOpenGl.cpp
@@ -13,8 +13,7 @@
 #include "OpenGlHelper.h"
 
 AlphaShaderOpenGl::AlphaShaderOpenGl(bool projectOntoUnitSphere)
-: projectOntoUnitSphere(projectOntoUnitSphere),
-programName(projectOntoUnitSphere ? "UBMAP_AlphaUnitSphereShaderOpenGl" : "UBMAP_AlphaShaderOpenGl") {}
+: programName(projectOntoUnitSphere ? "UBMAP_AlphaUnitSphereShaderOpenGl" : "UBMAP_AlphaShaderOpenGl") {}
 
 std::string AlphaShaderOpenGl::getProgramName() { return programName; }
 

--- a/android/src/main/cpp/graphics/shader/AlphaShaderOpenGl.h
+++ b/android/src/main/cpp/graphics/shader/AlphaShaderOpenGl.h
@@ -38,7 +38,6 @@ class AlphaShaderOpenGl : public BaseShaderProgramOpenGl,
     virtual std::string getFragmentShader() override;
 
   private:
-    const bool projectOntoUnitSphere;
     const std::string programName;
 
     float alpha = 1;

--- a/android/src/main/cpp/graphics/shader/ColorCircleShaderOpenGl.cpp
+++ b/android/src/main/cpp/graphics/shader/ColorCircleShaderOpenGl.cpp
@@ -13,8 +13,7 @@
 #include "OpenGlHelper.h"
 
 ColorCircleShaderOpenGl::ColorCircleShaderOpenGl(bool projectOntoUnitSphere)
-        : projectOntoUnitSphere(projectOntoUnitSphere),
-          programName(projectOntoUnitSphere ? "UBMAP_ColorCircleShaderUnitSphereOpenGl" : "UBMAP_ColorCircleShaderOpenGl") {}
+        : programName(projectOntoUnitSphere ? "UBMAP_ColorCircleShaderUnitSphereOpenGl" : "UBMAP_ColorCircleShaderOpenGl") {}
 
 std::string ColorCircleShaderOpenGl::getProgramName() { return programName; }
 

--- a/android/src/main/cpp/graphics/shader/ColorCircleShaderOpenGl.h
+++ b/android/src/main/cpp/graphics/shader/ColorCircleShaderOpenGl.h
@@ -37,7 +37,6 @@ class ColorCircleShaderOpenGl : public BaseShaderProgramOpenGl,
     virtual std::string getFragmentShader() override;
 
   private:
-    const bool projectOntoUnitSphere;
     const std::string programName;
 
     std::mutex dataMutex;

--- a/android/src/main/cpp/graphics/shader/ColorPolygonGroup2dShaderOpenGl.cpp
+++ b/android/src/main/cpp/graphics/shader/ColorPolygonGroup2dShaderOpenGl.cpp
@@ -15,8 +15,7 @@
 #include <cstring>
 
 ColorPolygonGroup2dShaderOpenGl::ColorPolygonGroup2dShaderOpenGl(bool isStriped, bool projectOntoUnitSphere)
-        : projectOntoUnitSphere(projectOntoUnitSphere),
-          isStriped(isStriped),
+        : isStriped(isStriped),
           programName(std::string("UBMAP_ColorPolygonGroupShaderOpenGl_") + (projectOntoUnitSphere ? "UnitSphere_" : "")
           + (isStriped ? "striped" : "std")) {
     this->polygonStyles.resize(sizeStyleValuesArray);
@@ -60,8 +59,6 @@ void ColorPolygonGroup2dShaderOpenGl::setupGlObjects(const std::shared_ptr<::Ope
                      GL_DYNAMIC_DRAW);
         glBindBuffer(GL_UNIFORM_BUFFER, 0);
     }
-
-    int program = context->getProgram(programName);
 }
 
 void ColorPolygonGroup2dShaderOpenGl::clearGlObjects() {

--- a/android/src/main/cpp/graphics/shader/ColorPolygonGroup2dShaderOpenGl.h
+++ b/android/src/main/cpp/graphics/shader/ColorPolygonGroup2dShaderOpenGl.h
@@ -48,7 +48,6 @@ protected:
   private:
     static std::string getPolygonStylesUBODefinition(bool isStriped);
 
-    bool projectOntoUnitSphere = false;
     bool isStriped = false;
     const std::string programName;
 

--- a/android/src/main/cpp/graphics/shader/ColorShaderOpenGl.cpp
+++ b/android/src/main/cpp/graphics/shader/ColorShaderOpenGl.cpp
@@ -12,8 +12,8 @@
 #include "OpenGlContext.h"
 
 ColorShaderOpenGl::ColorShaderOpenGl(bool projectOntoUnitSphere)
-        : programName(projectOntoUnitSphere ? "UBMAP_ColorShaderUnitSphereOpenGl" : "UBMAP_ColorShaderOpenGl"),
-          projectOntoUnitSphere(projectOntoUnitSphere) {}
+        : programName(projectOntoUnitSphere ? "UBMAP_ColorShaderUnitSphereOpenGl" : "UBMAP_ColorShaderOpenGl")
+{}
 
 std::string ColorShaderOpenGl::getProgramName() { return programName; }
 

--- a/android/src/main/cpp/graphics/shader/ColorShaderOpenGl.h
+++ b/android/src/main/cpp/graphics/shader/ColorShaderOpenGl.h
@@ -37,7 +37,6 @@ class ColorShaderOpenGl : public BaseShaderProgramOpenGl,
     virtual std::string getFragmentShader() override;
 
   private:
-    const bool projectOntoUnitSphere;
     const std::string programName;
 
     std::mutex dataMutex;

--- a/android/src/main/cpp/graphics/shader/RasterShaderOpenGl.cpp
+++ b/android/src/main/cpp/graphics/shader/RasterShaderOpenGl.cpp
@@ -13,8 +13,8 @@
 
 
 RasterShaderOpenGl::RasterShaderOpenGl(bool projectOntoUnitSphere)
-        : programName(projectOntoUnitSphere ? "UBMAP_RasterShaderUnitSphereOpenGl" : "UBMAP_RasterShaderOpenGl"),
-          projectOntoUnitSphere(projectOntoUnitSphere) {}
+        : programName(projectOntoUnitSphere ? "UBMAP_RasterShaderUnitSphereOpenGl" : "UBMAP_RasterShaderOpenGl")
+{}
 
 std::string RasterShaderOpenGl::getProgramName() {
     return programName;

--- a/android/src/main/cpp/graphics/shader/RasterShaderOpenGl.h
+++ b/android/src/main/cpp/graphics/shader/RasterShaderOpenGl.h
@@ -41,7 +41,6 @@ protected:
 
 private:
     const std::string programName;
-    bool projectOntoUnitSphere;
 
     std::mutex dataMutex;
     std::vector<GLfloat> styleValues = {1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0};

--- a/jvm/CMakeLists.txt
+++ b/jvm/CMakeLists.txt
@@ -19,9 +19,6 @@ file(GLOB_RECURSE mapscore_jni_SRC
 add_library(mapscore_jni SHARED ${mapscore_jni_SRC})
 
 target_include_directories(mapscore_jni PRIVATE
-  ../external/djinni/support-lib/jni
-  ${JNI_INCLUDE_DIRS}
-  
   ../bridging/android/jni/graphics
   ../bridging/android/jni/graphics/common
   ../bridging/android/jni/graphics/objects
@@ -41,12 +38,25 @@ target_include_directories(mapscore_jni PRIVATE
   ../bridging/android/jni/map/scheduling
   ../bridging/android/jni/map/coordinates
   ../bridging/android/jni/map/camera
-
+)
+target_include_directories(mapscore_jni SYSTEM PRIVATE
+  ../external/djinni/support-lib/jni
+  ${JNI_INCLUDE_DIRS}
   ${OSMESA_INCLUDE_DIRS}
 )
+
 target_compile_features(mapscore_jni PRIVATE cxx_std_20)
-target_compile_options(mapscore_jni PRIVATE -Werror -Wno-deprecated -Wno-reorder)
+target_compile_options(mapscore_jni PRIVATE -Werror -Wunused -Wno-deprecated-declarations)
 target_link_libraries(mapscore_jni mapscore ${OSMESA_LIBRARIES})
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+set_property(
+  SOURCE ../external/djinni/support-lib/jni/djinni_support.cpp
+  APPEND
+  PROPERTY COMPILE_OPTIONS
+  -Wno-unused)
+endif()
+
 # Fiddle with cmake system  TARGET_OS/TARGET_ARCH to form string "linux_amd64" for library filename.
 string(TOLOWER ${CMAKE_SYSTEM_NAME} TARGET_OS)
 string(REPLACE "x86_64" "amd64" TARGET_ARCHITECTURE ${CMAKE_SYSTEM_PROCESSOR})

--- a/jvm/src/main/cpp/jni/GlTextureHelper.cpp
+++ b/jvm/src/main/cpp/jni/GlTextureHelper.cpp
@@ -16,7 +16,6 @@ JNIEXPORT jint JNICALL Java_io_openmobilemaps_mapscore_graphics_util_GlTextureHe
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    const jsize outLen = env->GetArrayLength(data);
     jint *dataBuf = env->GetIntArrayElements(data, NULL);
 
     // NOTE: little-endian! Implicit byte-order conversion from ARGB ints (highest-order byte is A) into BGRA byte buffer

--- a/jvm/src/main/cpp/jni/OSMesa.cpp
+++ b/jvm/src/main/cpp/jni/OSMesa.cpp
@@ -132,7 +132,6 @@ JNIEXPORT void JNICALL Java_io_openmobilemaps_mapscore_graphics_util_OSMesa_read
     }
 
     // NOTE: little-endian! Implicit byte-order conversion from BGRA byte buffer into ARGB ints (highest-order byte is A)
-    const jsize outLen = env->GetArrayLength(out);
     jint *outBuf = env->GetIntArrayElements(out, NULL);
 
     // memcpy(outBuf, buf, sizeof(jint) * outLen); // NOTE for whatever reason, the blit above does not seem to directly affect

--- a/shared/public/ChronoUtil.h
+++ b/shared/public/ChronoUtil.h
@@ -15,19 +15,19 @@
 #include <string>
 
 namespace chronoutil {
-    static std::chrono::milliseconds getCurrentTimestamp() {
+    inline std::chrono::milliseconds getCurrentTimestamp() {
         return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch());
     }
 
-    static std::chrono::nanoseconds getCurrentTimestampNs() {
+    inline std::chrono::nanoseconds getCurrentTimestampNs() {
         return std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch());
     }
 
-    static std::string getTimestampDeltaString(std::chrono::milliseconds start, std::chrono::milliseconds end) {
+    inline std::string getTimestampDeltaString(std::chrono::milliseconds start, std::chrono::milliseconds end) {
         return std::to_string((end - start).count()) + "ms";
     }
 
-    static void logDebugTimeDeltaToNow(std::string tag, std::chrono::milliseconds start) {
+    inline void logDebugTimeDeltaToNow(std::string tag, std::chrono::milliseconds start) {
         LogDebug <<= tag + ": " + getTimestampDeltaString(start, getCurrentTimestamp());
     }
 }

--- a/shared/public/Circle2dLayerObject.h
+++ b/shared/public/Circle2dLayerObject.h
@@ -41,6 +41,4 @@ private:
     std::shared_ptr<Quad2dInterface> quad;
     std::shared_ptr<GraphicsObjectInterface> graphicsObject;
     std::shared_ptr<RenderConfig> renderConfig;
-
-    double radius = 0;
 };

--- a/shared/public/CoordinatesUtil.h
+++ b/shared/public/CoordinatesUtil.h
@@ -18,7 +18,7 @@
 
 namespace coordsutil {
 
-    static bool checkIntersectionRectCoords2d(const RectCoord &r1, const RectCoord &r2) {
+    inline bool checkIntersectionRectCoords2d(const RectCoord &r1, const RectCoord &r2) {
         assert(r1.topLeft.systemIdentifier == r2.topLeft.systemIdentifier);
         return !(std::min(r2.topLeft.x, r2.bottomRight.x) > std::max(r1.topLeft.x, r1.bottomRight.x) ||
                  std::max(r2.topLeft.x, r2.bottomRight.x) < std::min(r1.topLeft.x, r1.bottomRight.x) ||
@@ -26,7 +26,7 @@ namespace coordsutil {
                  std::max(r2.topLeft.y, r2.bottomRight.y) < std::min(r1.topLeft.y, r1.bottomRight.y));
     }
 
-    static bool checkRectContainsCoord(const RectCoord &rect, const Coord &coord, const std::shared_ptr<CoordinateConversionHelperInterface> &conversionHelper) {
+    inline bool checkRectContainsCoord(const RectCoord &rect, const Coord &coord, const std::shared_ptr<CoordinateConversionHelperInterface> &conversionHelper) {
         assert(rect.topLeft.systemIdentifier == rect.bottomRight.systemIdentifier);
         
         auto convCoord = conversionHelper->convert(rect.topLeft.systemIdentifier, coord);

--- a/shared/public/IconLayerObject.h
+++ b/shared/public/IconLayerObject.h
@@ -78,7 +78,6 @@ class IconLayerObject : public LayerObjectInterface, public std::enable_shared_f
 
     std::shared_ptr<AnimationInterface> animation;
 
-    float alpha = 1.0;
     bool is3d = false;
 
     Vec3D origin = Vec3D(0.0, 0.0, 0.0);

--- a/shared/public/LineGeometryBuilder.h
+++ b/shared/public/LineGeometryBuilder.h
@@ -38,7 +38,7 @@ class LineGeometryBuilder {
 
             float prefixTotalLineLength = 0.0;
             float lineLength = 0;
-            float cosAngle = 0, cosHalfAngle = 0;
+            float cosHalfAngle = 0;
 
             Vec3D pLast(0, 0, 0), normal(0, 0, 0), lastNormal(0, 0, 0), lineVec(0, 0, 0), lastLineVec(0, 0, 0),
                 pOriginLine(0, 0, 0);
@@ -104,14 +104,12 @@ class LineGeometryBuilder {
                         }
 
                         if (is3d) {
-                            cosAngle = Vec3DHelper::dotProduct(normal, lastNormal);
                             cosHalfAngle = Vec3DHelper::dotProduct(extrude, normal);
 
                             Vec3D cross = Vec3DHelper::crossProduct(lastLineVec, lineVec); // 3D cross product
                             turnDirection = Vec3DHelper::dotProduct(cross, pOriginLine);   // Project onto reference normal
 
                         } else {
-                            cosAngle = normal.x * lastNormal.x + normal.y * lastNormal.y;
                             cosHalfAngle = extrude.x * normal.x + extrude.y * normal.y;
                             turnDirection = (lastNormal.x * normal.y - lastNormal.y * normal.x); // 2D cross product
                         }
@@ -150,17 +148,12 @@ class LineGeometryBuilder {
                     float prefixCorrection = 0.0;
                     pushLineVertex(p, Vec3D(0, 0, 0), 1.0, 0, prefixTotalLineLength, prefixCorrection, lineStyleIndex, true, false, vertexCount,
                                    prePreIndex, preIndex, lineAttributes, lineIndices, is3d);
-                    int32_t centerIndex = preIndex, firstIndex = -1, lastIndex = -1;
+                    int32_t centerIndex = preIndex;
                     for (float r = -1; r <= 1; r += 0.2) {
                         Vec3D roundExtrude = Vec3DHelper::normalize(extrude * r - extrudeLineVec * (1.0 - std::abs(r)));
                         prefixCorrection = Vec3DHelper::dotProduct(roundExtrude, lastLineVec);
                         pushLineVertex(p, roundExtrude, 1.0, r, prefixTotalLineLength, prefixCorrection, lineStyleIndex, true, endSide == -1,
                                        vertexCount, prePreIndex, preIndex, lineAttributes, lineIndices, is3d);
-                        if (r == 0) {
-                            firstIndex = preIndex;
-                        } else {
-                            lastIndex = preIndex;
-                        }
                         prePreIndex = centerIndex;
                     }
                     prePreIndex = originalPrePreIndex;
@@ -286,17 +279,12 @@ class LineGeometryBuilder {
                     float prefixCorrection = 0;
                     pushLineVertex(p, Vec3D(0, 0, 0), 1.0, 0, prefixTotalLineLength, prefixCorrection, lineStyleIndex, true, false, vertexCount,
                                    prePreIndex, preIndex, lineAttributes, lineIndices, is3d);
-                    int32_t centerIndex = preIndex, firstIndex = -1, lastIndex = -1;
+                    int32_t centerIndex = preIndex;
                     for (float r = -1; r <= 1; r += 0.2) {
                         Vec3D roundExtrude = Vec3DHelper::normalize(extrude * r - extrudeLineVec * (1.0 - std::abs(r)));
                         float prefixCorrection = Vec3DHelper::dotProduct(roundExtrude, lineVec);
                         pushLineVertex(p, roundExtrude, 1.0, r, prefixTotalLineLength, prefixCorrection, lineStyleIndex, true, endSide == -1,
                                        vertexCount, prePreIndex, preIndex, lineAttributes, lineIndices, is3d);
-                        if (r == 0) {
-                            firstIndex = preIndex;
-                        } else {
-                            lastIndex = preIndex;
-                        }
                         prePreIndex = centerIndex;
                     }
                     prePreIndex = originalPrePreIndex;

--- a/shared/public/TextLayerObject.h
+++ b/shared/public/TextLayerObject.h
@@ -87,11 +87,6 @@ class TextLayerObject : public LayerObjectInterface {
 
     std::shared_ptr<TextShaderInterface> shader;
 
-    Vec2D currentSize = Vec2D(1.0, 1.0);
-    RectD currentUv = RectD(0.0, 0.0, 1.0, 1.0);
-    Anchor currentIconAnchor = Anchor::CENTER;
-    Vec2F currentIconOffset = Vec2F(0.0, 0.0);
-    
     std::vector<std::shared_ptr<RenderConfigInterface>> renderConfig;
 
     Coord referencePoint;
@@ -101,7 +96,6 @@ class TextLayerObject : public LayerObjectInterface {
 
     FontData fontData;
     Vec2F offset;
-    double lineHeight;
     double letterSpacing;
     double maxCharacterAngle;
     float spaceAdvance = 0.0f;
@@ -109,8 +103,6 @@ class TextLayerObject : public LayerObjectInterface {
     std::shared_ptr<MapCameraInterface> camera;
     std::optional<std::vector<::Coord>> lineCoordinates;
     std::vector<::Coord> renderLineCoordinates;
-
-    SymbolAlignment rotationAlignment;
 
 #ifdef DRAW_TEXT_LETTER_BOXES
     std::vector<Quad2dD> letterBoxes;

--- a/shared/public/Textured2dLayerObject.h
+++ b/shared/public/Textured2dLayerObject.h
@@ -88,6 +88,5 @@ class Textured2dLayerObject : public LayerObjectInterface, public std::enable_sh
 
     std::shared_ptr<AnimationInterface> animation;
 
-    float alpha = 1.0;
     bool is3d = false;
 };

--- a/shared/public/Tiled2dMapSourceImpl.h
+++ b/shared/public/Tiled2dMapSourceImpl.h
@@ -185,7 +185,7 @@ void Tiled2dMapSource<L, R>::onCameraChange(const std::vector<float> &viewMatrix
                         },
                         {})},
                     &currentViewBoundsPolygon);
-    auto clipAndFreeLambda = [&currentViewBoundsPolygon, system = layerSystemId](gpc_polygon &polygon) {
+    auto clipAndFreeLambda = [&currentViewBoundsPolygon](gpc_polygon &polygon) {
         gpc_polygon_clip(GPC_DIFF, &currentViewBoundsPolygon, &polygon, &currentViewBoundsPolygon);
         gpc_free_polygon(&polygon);
     };
@@ -547,10 +547,10 @@ void Tiled2dMapSource<L, R>::onCameraChange(const std::vector<float> &viewMatrix
                 const double tLength = tileWidth / 256;
                 const double tHeight = tileHeight / 256;
 
-                const double tileWidthAdj = leftToRight ? tileWidth : -tileWidth;
-                const double tileHeightAdj = topToBottom ? tileHeight : -tileHeight;
-                const double tWidthAdj = leftToRight ? tLength : -tLength;
-                const double tHeightAdj = topToBottom ? tHeight : -tHeight;
+                // const double tileWidthAdj = leftToRight ? tileWidth : -tileWidth;
+                // const double tileHeightAdj = topToBottom ? tileHeight : -tileHeight;
+                // const double tWidthAdj = leftToRight ? tLength : -tLength;
+                // const double tHeightAdj = topToBottom ? tHeight : -tHeight;
                 const double originX = leftToRight ? zoomLevelInfo.bounds.topLeft.x : -zoomLevelInfo.bounds.bottomRight.x;
                 const double originY = topToBottom ? zoomLevelInfo.bounds.bottomRight.y : -zoomLevelInfo.bounds.topLeft.y;
                 const double minAvailableX = leftToRight ? std::min(availableTiles.topLeft.x, availableTiles.bottomRight.x)
@@ -804,8 +804,8 @@ void Tiled2dMapSource<L, R>::onVisibleBoundsChanged(const ::RectCoord &visibleBo
 
             const double tLength = tileWidth / 256;
             const double tHeight = tileHeight / 256;
-            const double tWidthAdj = leftToRight ? tLength : -tLength;
-            const double tHeightAdj = topToBottom ? tHeight : -tHeight;
+            // const double tWidthAdj = leftToRight ? tLength : -tLength;
+            // const double tHeightAdj = topToBottom ? tHeight : -tHeight;
             const double originX = leftToRight ? zoomLevelInfo.bounds.topLeft.x : -zoomLevelInfo.bounds.bottomRight.x;
             const double originY = topToBottom ? zoomLevelInfo.bounds.bottomRight.y : -zoomLevelInfo.bounds.topLeft.y;
             const double minAvailableX = leftToRight ? std::min(availableTiles.topLeft.x, availableTiles.bottomRight.x)

--- a/shared/src/map/camera/MapCamera2d.cpp
+++ b/shared/src/map/camera/MapCamera2d.cpp
@@ -706,7 +706,6 @@ bool MapCamera2d::onDoubleClick(const ::Vec2F &posScreen) {
 
     auto position = coordFromScreenPosition(posScreen);
 
-    auto config = mapInterface->getMapConfig();
     auto bottomRight = bounds.bottomRight;
     auto topLeft = bounds.topLeft;
 
@@ -734,7 +733,6 @@ bool MapCamera2d::onTwoFingerClick(const ::Vec2F &posScreen1, const ::Vec2F &pos
 
     auto position = coordFromScreenPosition(Vec2FHelper::midpoint(posScreen1, posScreen2));
 
-    auto config = mapInterface->getMapConfig();
     auto bottomRight = bounds.bottomRight;
     auto topLeft = bounds.topLeft;
 

--- a/shared/src/map/camera/MapCamera3d.cpp
+++ b/shared/src/map/camera/MapCamera3d.cpp
@@ -471,7 +471,6 @@ std::optional<std::tuple<std::vector<double>, std::vector<double>, Vec3D>> MapCa
     // aspect ratio
     const double vpr = (double)sizeViewport.x / (double)sizeViewport.y;
     double fovy = fovx / vpr;
-    const double fovyRad = fovy * M_PI / 180.0;
 
     // initial perspective projection
     std::vector<double> basicProjectionMatrix(16, 0.0);
@@ -727,13 +726,12 @@ RectCoord MapCamera3d::getRectFromViewport(const Vec2I &sizeViewport, const Coor
 
 void MapCamera3d::notifyListeners(const int &listenerType) {
     // TODO: Add back bounds listener as soon as visibleRect is implemented correctly
-    std::optional<RectCoord> visibleRect =
-        (listenerType & ListenerType::BOUNDS) ? std::optional<RectCoord>(getVisibleRect()) : std::nullopt;
+    // std::optional<RectCoord> visibleRect =
+    //     (listenerType & ListenerType::BOUNDS) ? std::optional<RectCoord>(getVisibleRect()) : std::nullopt;
 
     //    std::optional<RectCoord> visibleRect = std::nullopt;
 
     double angle = this->angle;
-    double zoom = this->zoom;
 
     std::vector<float> viewMatrix;
     std::vector<float> projectionMatrix;
@@ -802,8 +800,8 @@ bool MapCamera3d::onTouchDown(const ::Vec2F &posScreen) {
         initialTouchDownPoint = posScreen;
         lastOnTouchDownFocusCoord = focusPointPosition;
 
-        auto northPole = screenPosFromCoord(Coord(CoordinateSystemIdentifiers::EPSG4326(), 0, 90, 0));
-        auto southPole = screenPosFromCoord(Coord(CoordinateSystemIdentifiers::EPSG4326(), 0, -90, 0));
+        // auto northPole = screenPosFromCoord(Coord(CoordinateSystemIdentifiers::EPSG4326(), 0, 90, 0));
+        // auto southPole = screenPosFromCoord(Coord(CoordinateSystemIdentifiers::EPSG4326(), 0, -90, 0));
         lastOnTouchDownCoord = coordFromScreenPosition(posScreen);
         reverseLongitudeRotation = std::abs(focusPointPosition.x - lastOnTouchDownCoord->x) > 90;
         return true;
@@ -1643,7 +1641,6 @@ void MapCamera3d::setCameraConfig(const Camera3dConfig &config, std::optional<fl
         return;
     }
 
-    auto viewport = mapInterface->getRenderingContext()->getViewportSize();
     auto viewPortSize = renderingContext->getViewportSize();
 
     if (durationSeconds && viewPortSize.x > 0 && viewPortSize.y > 0) {
@@ -1806,9 +1803,6 @@ double MapCamera3d::zoomForMeterWidth(Vec2I sizeViewport, Vec2F sizeMeters) {
     if (vpr < 1) {
         vpr = 1.0 / vpr;
     }
-
-    double vprX = 1.0;
-    double vprY = 1.0;
 
     double fx = getCameraFieldOfView();
     double halfAngleRadianX = fx * 0.5 * M_PI / 180.0;

--- a/shared/src/map/controls/DefaultTouchHandler.cpp
+++ b/shared/src/map/controls/DefaultTouchHandler.cpp
@@ -18,7 +18,6 @@
 
 DefaultTouchHandler::DefaultTouchHandler(std::shared_ptr<SchedulerInterface> scheduler, float density)
     : scheduler(scheduler)
-    , density(density)
     , clickDistancePx(CLICK_DISTANCE_MM * density / 25.4)
     , state(IDLE)
     , stateTime(0)
@@ -169,7 +168,7 @@ void DefaultTouchHandler::handleTouchDown(Vec2F position) {
     if (strongScheduler) {
         strongScheduler->addTask(std::make_shared<LambdaTask>(
                                                               TaskConfig("LongPressTask", LONG_PRESS_TIMEOUT, TaskPriority::NORMAL, ExecutionEnvironment::COMPUTATION),
-                                                              [=] { checkState(); }));
+                                                              [this] { checkState(); }));
     }
     {
         std::lock_guard<std::recursive_mutex> lock(listenerMutex);
@@ -275,7 +274,7 @@ void DefaultTouchHandler::handleTouchUp() {
             if (strongScheduler) {
                 strongScheduler->addTask(std::make_shared<LambdaTask>(
                                                                       TaskConfig("DoubleTapTask", DOUBLE_TAP_TIMEOUT, TaskPriority::NORMAL, ExecutionEnvironment::COMPUTATION),
-                                                                      [=] { checkState(); }));
+                                                                      [this] { checkState(); }));
             }
         }
 
@@ -311,7 +310,7 @@ void DefaultTouchHandler::handleTouchUp() {
             if (strongScheduler) {
                 strongScheduler->addTask(std::make_shared<LambdaTask>(
                                                                       TaskConfig("OneFingerAfterTwoTask", TWO_FINGER_TOUCH_TIMEOUT, TaskPriority::NORMAL, ExecutionEnvironment::COMPUTATION),
-                                                                      [=] { checkState(); }));
+                                                                      [this] { checkState(); }));
             }
         }
         else {
@@ -361,7 +360,7 @@ void DefaultTouchHandler::handleTwoFingerDown() {
     if (strongScheduler) {
         strongScheduler->addTask(std::make_shared<LambdaTask>(
                                                               TaskConfig("LongPressTask", LONG_PRESS_TIMEOUT, TaskPriority::NORMAL, ExecutionEnvironment::COMPUTATION),
-                                                              [=] { checkState(); }));
+                                                              [this] { checkState(); }));
     }
     {
         std::lock_guard<std::recursive_mutex> lock(listenerMutex);
@@ -411,7 +410,7 @@ void DefaultTouchHandler::handleTwoFingerUp(std::tuple<Vec2F, Vec2F> doubleTouch
         if (strongScheduler) {
             strongScheduler->addTask(std::make_shared<LambdaTask>(
                                                                   TaskConfig("OneFingerAfterTwoTask", TWO_FINGER_TOUCH_TIMEOUT, TaskPriority::NORMAL, ExecutionEnvironment::COMPUTATION),
-                                                                  [=] { checkState(); }));
+                                                                  [this] { checkState(); }));
         }
         {
             std::lock_guard<std::recursive_mutex> lock(listenerMutex);

--- a/shared/src/map/controls/DefaultTouchHandler.h
+++ b/shared/src/map/controls/DefaultTouchHandler.h
@@ -73,7 +73,6 @@ private:
     int32_t LONG_PRESS_TIMEOUT = 500;
     int32_t CLICK_DISTANCE_MM = 3;
 
-    float density;
     float clickDistancePx;
 
     std::recursive_mutex listenerMutex;

--- a/shared/src/map/layers/icon/IconLayer.cpp
+++ b/shared/src/map/layers/icon/IconLayer.cpp
@@ -206,7 +206,6 @@ void IconLayer::setupIconObjects(
     }
 
     for (const auto &iconPair : iconObjects) {
-        const auto &icon = iconPair.first;
         const auto &iconObject = iconPair.second;
 
         iconObject->setup(renderingContext);

--- a/shared/src/map/layers/objects/IconLayerObject.cpp
+++ b/shared/src/map/layers/objects/IconLayerObject.cpp
@@ -75,10 +75,8 @@ void IconLayerObject::update() {
 
     if(!context || !camera) { return; }
 
-    auto zoom = camera->getZoom();
     auto viewport = context->getViewportSize();
 
-    const double rotation = camera->getRotation();
     const auto scaleFactor = camera->getScalingFactor();
 
     auto iconSize = icon->getIconSize();

--- a/shared/src/map/layers/objects/Line2dLayerObject.cpp
+++ b/shared/src/map/layers/objects/Line2dLayerObject.cpp
@@ -95,7 +95,6 @@ void Line2dLayerObject::setStyle(const LineStyle &style, bool highlighted) {
     s.blur = toHalfFloat(style.blur);
 
     // width type
-    auto widthType = SizeType::SCREEN_PIXEL;
     auto widthAsPixel = (style.widthType == SizeType::SCREEN_PIXEL ? 1 : 0);
     s.widthAsPixel = toHalfFloat(widthAsPixel);
 

--- a/shared/src/map/layers/objects/LineGroup2dLayerObject.cpp
+++ b/shared/src/map/layers/objects/LineGroup2dLayerObject.cpp
@@ -125,8 +125,6 @@ void LineGroup2dLayerObject::setStyles(const std::vector<LineStyle> &styles) {
         auto dValue2 = (dn > 2 ? s.dashArray[2] : 0.0) + dValue1;
         auto dValue3 = (dn > 3 ? s.dashArray[3] : 0.0) + dValue2;
 
-        float dotted = s.dotted ? 0 : 1;
-
         shaderLineStyles.emplace_back(ShaderLineStyle{toHalfFloat(s.width),
                                                       toHalfFloat(s.color.normal.r),
                                                       toHalfFloat(s.color.normal.g),

--- a/shared/src/map/layers/objects/PolygonGroup2dLayerObject.cpp
+++ b/shared/src/map/layers/objects/PolygonGroup2dLayerObject.cpp
@@ -67,7 +67,6 @@ void PolygonGroup2dLayerObject::setVertices(const std::vector<std::tuple<std::ve
     for (size_t i = 0; i < renderVertices.size(); i += 4) { // 4 values: x, y, z, s
         const auto& x = renderVertices[i];
         const auto& y = renderVertices[i + 1];
-        const auto& z = renderVertices[i + 2];
 
         // Adjust the coordinates by subtracting the average
         if(is3d) {

--- a/shared/src/map/layers/objects/PolygonPatternGroup2dLayerObject.cpp
+++ b/shared/src/map/layers/objects/PolygonPatternGroup2dLayerObject.cpp
@@ -69,7 +69,6 @@ void PolygonPatternGroup2dLayerObject::setVertices(const std::vector<std::tuple<
     for (size_t i = 0; i < renderVertices.size(); i += 4) { // 4 values: x, y, z, s
         double x = renderVertices[i];
         double y = renderVertices[i + 1];
-        double z = renderVertices[i + 2];
 
         // Adjust the coordinates by subtracting the average
         if(is3d) {

--- a/shared/src/map/layers/objects/QuadMaskObject.cpp
+++ b/shared/src/map/layers/objects/QuadMaskObject.cpp
@@ -55,7 +55,7 @@ void QuadMaskObject::setPositions(const QuadCoord &coords) {
         origin.z = -1.0 * sin(cy) * sin(cx);
     }
     
-    auto transform = [&origin](const Coord coordinate) -> Vec3D {
+    auto transform = [](const Coord coordinate) -> Vec3D {
         double x = coordinate.x;
         double y = coordinate.y;
         double z = coordinate.z;

--- a/shared/src/map/layers/objects/Textured2dLayerObject.cpp
+++ b/shared/src/map/layers/objects/Textured2dLayerObject.cpp
@@ -74,7 +74,7 @@ void Textured2dLayerObject::setPositions(const ::QuadCoord &coords) {
         origin.z = -1.0 * sin(cy) * sin(cx);
     }
 
-    auto transform = [&origin](const Coord coordinate) -> Vec3D {
+    auto transform = [](const Coord coordinate) -> Vec3D {
         const double x = coordinate.x;
         const double y = coordinate.y;
         const double z = coordinate.z;

--- a/shared/src/map/layers/text/TextLayerObject.cpp
+++ b/shared/src/map/layers/text/TextLayerObject.cpp
@@ -34,10 +34,9 @@ TextLayerObject::TextLayerObject(const std::shared_ptr<TextInterface> &text, con
   referencePoint(Coord(0, 0.0, 0.0, 0.0)),
   fontData(fontData),
   offset(offset),
-  lineHeight(lineHeight),
   letterSpacing(letterSpacing),
   maxCharacterAngle(maxCharacterAngle),
-  boundingBox(Coord(0, 0.0, 0.0, 0.0), Coord(0, 0.0, 0.0, 0.0)), rotationAlignment(rotationAlignment)
+  boundingBox(Coord(0, 0.0, 0.0, 0.0), Coord(0, 0.0, 0.0, 0.0))
 {
     if (text) {
         renderConfig = { std::make_shared<RenderConfig>(text->asGraphicsObject(), 1) };

--- a/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayer.cpp
+++ b/shared/src/map/layers/tiled/vector/Tiled2dMapVectorLayer.cpp
@@ -456,8 +456,7 @@ void Tiled2dMapVectorLayer::initializeVectorLayer() {
                                                                         vectorSource.weakActor<Tiled2dMapVectorSource>(),
                                                                         readyManager,
                                                                         featureStateManager,
-                                                                        symbolDelegate,
-                                                                        mapDescription->persistingSymbolPlacement);
+                                                                        symbolDelegate);
             actor.unsafe()->setAlpha(alpha);
             actor.unsafe()->enableAnimations(animationsEnabled);
             symbolSourceDataManagers[source] = actor;
@@ -939,7 +938,7 @@ void Tiled2dMapVectorLayer::loadSpriteData(int scale, bool fromLocal) {
 
     auto castedMe = std::static_pointer_cast<Tiled2dMapVectorLayer>(shared_from_this());
     std::weak_ptr<Tiled2dMapVectorLayer> weakSelf = castedMe;
-    jsonLoaderFuture->then([context, scale, weakSelf, fromLocal] (auto result) {
+    jsonLoaderFuture->then([context] (auto result) {
         context->jsonResult =  std::make_shared<DataLoaderResult>(result.get());
         
         if (--(context->counter) == 0) {

--- a/shared/src/map/layers/tiled/vector/geojson/geojsonvt/clip.hpp
+++ b/shared/src/map/layers/tiled/vector/geojson/geojsonvt/clip.hpp
@@ -116,7 +116,6 @@ private:
 
     void clipLine(const std::vector<Coord>& line,std::vector<std::vector<Coord>> &slices) const {
         const size_t len = line.size();
-        double segLen = 0.0;
         double t = 0.0;
 
         if (len < 2)

--- a/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSourceSymbolDataManager.cpp
+++ b/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSourceSymbolDataManager.cpp
@@ -27,13 +27,12 @@ Tiled2dMapVectorSourceSymbolDataManager::Tiled2dMapVectorSourceSymbolDataManager
                                                                                  const WeakActor<Tiled2dMapVectorSource> &vectorSource,
                                                                                  const Actor<Tiled2dMapVectorReadyManager> &readyManager,
                                                                                  const std::shared_ptr<Tiled2dMapVectorStateManager> &featureStateManager,
-                                                                                 const std::shared_ptr<Tiled2dMapVectorLayerSymbolDelegateInterface> &symbolDelegate,
-                                                                                 bool persistingSymbolPlacement)
+                                                                                 const std::shared_ptr<Tiled2dMapVectorLayerSymbolDelegateInterface> &symbolDelegate)
         : Tiled2dMapVectorSourceDataManager(vectorLayer, mapDescription, layerConfig, source, readyManager, featureStateManager),
         fontLoader(fontLoader), vectorSource(vectorSource),
         animationCoordinatorMap(std::make_shared<SymbolAnimationCoordinatorMap>()),
-        symbolDelegate(symbolDelegate),
-        persistingSymbolPlacement(persistingSymbolPlacement) {
+        symbolDelegate(symbolDelegate)
+{
 
     for (const auto &layer: mapDescription->layers) {
         if (layer->getType() == VectorLayerType::symbol && layer->source == source) {
@@ -457,8 +456,7 @@ std::vector<Actor<Tiled2dMapVectorSymbolGroup>> Tiled2dMapVectorSourceSymbolData
                                                                                                  layerDescriptions.at(
                                                                                                          layerIdentifier),
                                                                                                  featureStateManager,
-                                                                                                 symbolDelegate,
-                                                                                                 persistingSymbolPlacement);
+                                                                                                 symbolDelegate);
         symbolGroupActor.message(MFN(&Tiled2dMapVectorSymbolGroup::initialize), features, featuresBase,
                                  std::min(featuresBase + maxNumFeaturesPerGroup, numFeatures) - featuresBase,
                                  animationCoordinatorMap, selfActor, alpha);
@@ -692,7 +690,6 @@ bool Tiled2dMapVectorSourceSymbolDataManager::update(long long now) {
             continue;
         }
         for (const auto &[layerIdentifier, symbolGroups]: symbolGroupsMap) {
-            const auto &description = layerDescriptions.at(layerIdentifier);
             for (auto &symbolGroup: std::get<1>(symbolGroups)) {
                 symbolGroup.syncAccess([&zoomIdentifier, &rotation, &scaleFactor, &now, &viewPortSize, &vpMatrix, &origin](auto group){
                     group->update(zoomIdentifier, rotation, scaleFactor, now, viewPortSize, vpMatrix, origin);

--- a/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSourceSymbolDataManager.h
+++ b/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSourceSymbolDataManager.h
@@ -63,8 +63,7 @@ public:
                                             const WeakActor<Tiled2dMapVectorSource> &vectorSource,
                                             const Actor<Tiled2dMapVectorReadyManager> &readyManager,
                                             const std::shared_ptr<Tiled2dMapVectorStateManager> &featureStateManager,
-                                            const std::shared_ptr<Tiled2dMapVectorLayerSymbolDelegateInterface> &symbolDelegate,
-                                            bool persistingSymbolPlacement);
+                                            const std::shared_ptr<Tiled2dMapVectorLayerSymbolDelegateInterface> &symbolDelegate);
 
     void onAdded(const std::weak_ptr<::MapInterface> &mapInterface) override;
 
@@ -151,8 +150,6 @@ private:
 
     std::shared_ptr<SymbolAnimationCoordinatorMap> animationCoordinatorMap;
     std::shared_ptr<Tiled2dMapVectorLayerSymbolDelegateInterface> symbolDelegate;
-
-    bool persistingSymbolPlacement = false;
 
 #ifdef OPENMOBILEMAPS_GL
     // Higher counts can't be handled due to the limited UBO size

--- a/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSymbolGroup.cpp
+++ b/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSymbolGroup.cpp
@@ -29,8 +29,7 @@ Tiled2dMapVectorSymbolGroup::Tiled2dMapVectorSymbolGroup(uint32_t groupId,
                                                          const std::string &layerIdentifier,
                                                          const std::shared_ptr<SymbolVectorLayerDescription> &layerDescription,
                                                          const std::shared_ptr<Tiled2dMapVectorStateManager> &featureStateManager,
-                                                         const std::shared_ptr<Tiled2dMapVectorLayerSymbolDelegateInterface> &symbolDelegate,
-                                                         const bool persistingSymbolPlacement)
+                                                         const std::shared_ptr<Tiled2dMapVectorLayerSymbolDelegateInterface> &symbolDelegate)
 : groupId(groupId),
 mapInterface(mapInterface),
 vectorLayer(vectorLayer),
@@ -42,7 +41,6 @@ fontProvider(fontProvider),
 featureStateManager(featureStateManager),
 symbolDelegate(symbolDelegate),
 usedKeys(layerDescription->getUsedKeys()),
-persistingSymbolPlacement(persistingSymbolPlacement),
 tileOrigin(0, 0, 0),
 is3d(mapInterface.lock()->is3d()){
     if (auto strongMapInterface = mapInterface.lock()) {
@@ -655,7 +653,7 @@ void Tiled2dMapVectorSymbolGroup::update(const double zoomIdentifier, const doub
                     auto &name = font->fontData->info.name;
 
                     const auto &textDescriptor = std::find_if(textDescriptors.begin(), textDescriptors.end(),
-                                                              [&font, &name](const auto &textDescriptor) {
+                                                              [&name](const auto &textDescriptor) {
                         return name == textDescriptor->fontResult->fontData->info.name;
                     });
 
@@ -1042,7 +1040,7 @@ Tiled2dMapVectorSymbolGroup::createSymbolObject(const Tiled2dMapVersionedTileInf
                                                           description, featureContext, text, fullText, coordinate, lineCoordinates,
                                                           fontList, textAnchor, angle, textJustify, textSymbolPlacement, hideIcon, animationCoordinatorMap,
                                                           featureStateManager, usedKeys, symbolTileIndex, hasCustomTexture, dpFactor,
-                                                          persistingSymbolPlacement, is3d, tileOrigin, styleIndex);
+                                                          is3d, tileOrigin, styleIndex);
     symbolObject->setAlpha(alpha);
     const auto counts = symbolObject->getInstanceCounts();
     if (counts.icons + counts.stretchedIcons + counts.textCharacters == 0) {

--- a/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSymbolGroup.h
+++ b/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSymbolGroup.h
@@ -45,8 +45,7 @@ public:
                                 const std::string &layerIdentifier,
                                 const std::shared_ptr<SymbolVectorLayerDescription> &layerDescription,
                                 const std::shared_ptr<Tiled2dMapVectorStateManager> &featureStateManager,
-                                const std::shared_ptr<Tiled2dMapVectorLayerSymbolDelegateInterface> &symbolDelegate,
-                                const bool persistingSymbolPlacement);
+                                const std::shared_ptr<Tiled2dMapVectorLayerSymbolDelegateInterface> &symbolDelegate);
 
     void initialize(std::weak_ptr<std::vector<Tiled2dMapVectorTileInfo::FeatureTuple>> weakFeatures,
                     int32_t featuresBase,
@@ -111,7 +110,6 @@ private:
     const std::string layerIdentifier;
     std::shared_ptr<SymbolVectorLayerDescription> layerDescription;
     const WeakActor<Tiled2dMapVectorFontProvider> fontProvider;
-    const bool persistingSymbolPlacement = false;
 
     std::shared_ptr<Quad2dInstancedInterface> iconInstancedObject;
     std::shared_ptr<Quad2dStretchedInstancedInterface> stretchedInstancedObject;

--- a/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSymbolLabelObject.cpp
+++ b/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSymbolLabelObject.cpp
@@ -236,7 +236,7 @@ void Tiled2dMapVectorSymbolLabelObject::precomputeMedianIfNeeded() {
             auto scale = i.scale;
             auto size = Vec2D(d.boundingBoxSize.x * scale, d.boundingBoxSize.y * scale);
             auto bearing = Vec2D(d.bearing.x * scale, d.bearing.y * scale);
-            auto advance = Vec2D(d.advance.x * scale, d.advance.y * scale);
+            // auto advance = Vec2D(d.advance.x * scale, d.advance.y * scale);
 
             if(i.glyphIndex != spaceIndex) {
                 auto y = penY - bearing.y;
@@ -301,8 +301,6 @@ int Tiled2dMapVectorSymbolLabelObject::getCharacterCount(){
 }
 
 void Tiled2dMapVectorSymbolLabelObject::setupProperties(VectorModificationWrapper<float> &textureCoordinates, VectorModificationWrapper<uint16_t> &styleIndices, int &countOffset, const double zoomIdentifier) {
-    const auto evalContext = EvaluationContext(zoomIdentifier, dpFactor, featureContext, stateManager);
-
     evaluateStyleProperties(zoomIdentifier);
 
     for(auto &i : splittedTextInfo) {
@@ -376,8 +374,6 @@ void Tiled2dMapVectorSymbolLabelObject::evaluateStyleProperties(const double zoo
 
 
 void Tiled2dMapVectorSymbolLabelObject::updateProperties(VectorModificationWrapper<float> &positions, VectorModificationWrapper<float> &referencePositions, VectorModificationWrapper<float> &scales, VectorModificationWrapper<float> &rotations, VectorModificationWrapper<float> &alphas, VectorModificationWrapper<float> &styles, int &countOffset, const double zoomIdentifier, const double scaleFactor, const bool collides, const double rotation, const float alpha, const bool isCoordinateOwner, long long now, const Vec2I &viewportSize, const std::vector<float>& vpMatrix, const Vec3D& origin) {
-    const auto evalContext = EvaluationContext(zoomIdentifier, dpFactor, featureContext, stateManager);
-
     evaluateStyleProperties(zoomIdentifier);
 
     float alphaFactor;
@@ -447,7 +443,6 @@ void Tiled2dMapVectorSymbolLabelObject::updateProperties(VectorModificationWrapp
 
 void Tiled2dMapVectorSymbolLabelObject::updatePropertiesPoint(VectorModificationWrapper<float> &positions, VectorModificationWrapper<float> &referencePositions, VectorModificationWrapper<float> &scales, VectorModificationWrapper<float> &rotations, VectorModificationWrapper<float> &alphas, int &countOffset, float alphaFactor, const double zoomIdentifier, const double scaleFactor, const double rotation, const Vec2I &viewportSize) {
 
-    const auto evalContext = EvaluationContext(zoomIdentifier, dpFactor, featureContext, stateManager);
     const float fontSize = is3d ? textSize.value : (scaleFactor * textSize.value);
 
     Vec2D boxMin(std::numeric_limits<float>::max(), std::numeric_limits<float>::max());
@@ -471,7 +466,6 @@ void Tiled2dMapVectorSymbolLabelObject::updatePropertiesPoint(VectorModification
     pen.y -= fontSize * lineHeight * 0.25;
 
     int numberOfCharacters = 0;
-    int baseLineStartIndex = 0;
     int lineEndIndicesIndex = 0;
     const auto &glyphs = fontResult->fontData->glyphs;
 
@@ -530,8 +524,6 @@ void Tiled2dMapVectorSymbolLabelObject::updatePropertiesPoint(VectorModification
             }
             pen.x = 0.0;
             pen.y += fontSize * lineHeight;
-
-            baseLineStartIndex = numberOfCharacters;
         }
         else {
             assert(false);
@@ -647,8 +639,8 @@ void Tiled2dMapVectorSymbolLabelObject::updatePropertiesPoint(VectorModification
     lut::sincos(angle * M_PI / 180.0, sinAngle, cosAngle);
     Vec2D anchorOffsetRot = Vec2DHelper::rotate(anchorOffset, Vec2D(0, 0), sinAngle, cosAngle);
 
-    const auto dx = referencePoint.x + anchorOffset.x;
-    const auto dy = referencePoint.y + anchorOffset.y;
+    // const auto dx = referencePoint.x + anchorOffset.x;
+    // const auto dy = referencePoint.y + anchorOffset.y;
     const auto dxRot = referencePoint.x + anchorOffsetRot.x;
     const auto dyRot = referencePoint.y + anchorOffsetRot.y;
 
@@ -718,7 +710,7 @@ void Tiled2dMapVectorSymbolLabelObject::updatePropertiesPoint(VectorModification
         boundingBoxCircles = std::nullopt;
     } else {
         std::vector<CircleD> circles;
-        Vec2D origin = Vec2D(dx, dy);
+        // Vec2D origin = Vec2D(dx, dy);
         Vec2D lastCirclePosition = Vec2D(0, 0);
         const double distanceThreshold = (2.0 * maxSymbolRadius) * collisionDistanceBias;
         const double distanceThresholdSq = distanceThreshold * distanceThreshold;
@@ -744,8 +736,6 @@ double Tiled2dMapVectorSymbolLabelObject::updatePropertiesLine(VectorModificatio
         countOffset += characterCount;
         return 0;
     }
-
-    auto evalContext = EvaluationContext(zoomIdentifier, dpFactor, featureContext, stateManager);
 
     const double fontSize = scaleFactor * textSize.value;
     const double scaleCorrection = is3d ? (1.0 / scaleFactor) : 1.0;
@@ -945,7 +935,7 @@ double Tiled2dMapVectorSymbolLabelObject::updatePropertiesLine(VectorModificatio
         }
     }
 
-    int countBefore = countOffset;
+    [[ maybe_unused ]] int countBefore = countOffset;
     if (!centerPositions.empty()) {
         assert(centerPositions.size() == characterCount);
 

--- a/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSymbolObject.cpp
+++ b/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSymbolObject.cpp
@@ -47,7 +47,6 @@ Tiled2dMapVectorSymbolObject::Tiled2dMapVectorSymbolObject(const std::weak_ptr<M
                                                            const size_t symbolTileIndex,
                                                            const bool hasCustomTexture,
                                                            const double dpFactor,
-                                                           const bool persistingSymbolPlacement,
                                                            bool is3d,
                                                            const Vec3D &tileOrigin,
                                                            const uint16_t styleIndex) :
@@ -66,7 +65,6 @@ Tiled2dMapVectorSymbolObject::Tiled2dMapVectorSymbolObject(const std::weak_ptr<M
     is3d(is3d),
     positionSize(is3d ? 3 : 2),
     tileOrigin(tileOrigin),
-    persistingSymbolPlacement(persistingSymbolPlacement),
     angle(angle),
     systemIdentifier(tileInfo.tileInfo.bounds.topLeft.systemIdentifier) {
     auto strongMapInterface = mapInterface.lock();

--- a/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSymbolObject.h
+++ b/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSymbolObject.h
@@ -51,7 +51,6 @@ public:
                                  const size_t symbolTileIndex,
                                  const bool hasCustomTexture,
                                  const double dpFactor,
-                                 const bool persistingSymbolPlacement,
                                  bool is3d,
                                  const Vec3D &tileOrigin,
                                  const uint16_t styleIndex);
@@ -171,8 +170,6 @@ private:
     FeatureValueEvaluationResult<bool> textAllowOverlap = false;
     FeatureValueEvaluationResult<bool> iconAllowOverlap = false;
 
-    bool persistingSymbolPlacement = false;
-
     double dpFactor = 1.0;
     float alpha = 1.0;
     bool isIconOpaque = true;
@@ -196,8 +193,6 @@ private:
     std::optional<RectI> customIconUv;
 
     size_t contentHash = 0;
-
-    double maxCollisionZoom = -1;
 
     bool isPlaced();
 

--- a/shared/src/map/layers/tiled/vector/tiles/polygon/Tiled2dMapVectorPolygonPatternTile.cpp
+++ b/shared/src/map/layers/tiled/vector/tiles/polygon/Tiled2dMapVectorPolygonPatternTile.cpp
@@ -189,8 +189,6 @@ void Tiled2dMapVectorPolygonPatternTile::setVectorTileData(const Tiled2dMapVecto
 
         std::unordered_map<size_t, bool> filterCache;
         
-        std::int32_t indices_offset = 0;
-
         for (auto featureIt = tileData->begin(); featureIt != tileData->end(); featureIt++) {
 
             const auto [featureContext, geometryHandler] = *featureIt;

--- a/shared/src/utils/ReverseGeocoder.cpp
+++ b/shared/src/utils/ReverseGeocoder.cpp
@@ -83,8 +83,6 @@ std::vector<::VectorLayerFeatureCoordInfo> ReverseGeocoder::reverseGeocode(const
         return resultVector;
     }
 
-    auto targetVec = Vec2D(converted.x, converted.y);
-
 
     // Calculate the bounds
     double minx = x * tileSize - ORIGIN_SHIFT;
@@ -95,8 +93,6 @@ std::vector<::VectorLayerFeatureCoordInfo> ReverseGeocoder::reverseGeocode(const
     auto topLeft = Coord(CoordinateSystemIdentifiers::EPSG3857(), minx, maxy, 0.0);
     auto bottomRight = Coord(CoordinateSystemIdentifiers::EPSG3857(), maxx, miny, 0.0);
     auto tileBounds = RectCoord(topLeft, bottomRight);
-
-    auto conv = conversionHelper->convertRect(4326, tileBounds);
 
     StringInterner stringTable = ValueKeys::newStringInterner();
     try {

--- a/shared/test/CMakeLists.txt
+++ b/shared/test/CMakeLists.txt
@@ -22,8 +22,12 @@ add_executable(tests
   "helper/TestLocalDataProvider.h"
 )
 # Use mapscore _private_ include to allow testing functionality declared in internal headers.
+# Use regex to reconstruct -I vs -isystem for external libs. Not nice, but cant find other cmake way.
+target_include_directories(tests SYSTEM PRIVATE
+  "$<FILTER:$<TARGET_PROPERTY:mapscore,INCLUDE_DIRECTORIES>,INCLUDE,../external>"
+)
 target_include_directories(tests PRIVATE
-  "$<TARGET_PROPERTY:mapscore,INCLUDE_DIRECTORIES>"
+  "$<FILTER:$<TARGET_PROPERTY:mapscore,INCLUDE_DIRECTORIES>,EXCLUDE,../external>"
 )
 cmake_path(SET TESTDATA_DIR "data/")
 cmake_path(ABSOLUTE_PATH TESTDATA_DIR NORMALIZE)
@@ -33,7 +37,7 @@ target_compile_definitions(tests PRIVATE
   OPENMOBILEMAPS_TESTDATA_DIR=${TESTDATA_DIR}
 )
 target_compile_features(tests PRIVATE cxx_std_20)
-target_compile_options(tests PRIVATE -Werror -Wno-deprecated)
+target_compile_options(tests PRIVATE -Werror -Wunused -Wno-deprecated-declarations)
 
 # Test via CTest 
 enable_testing()

--- a/shared/test/TestGeometryHandler.cpp
+++ b/shared/test/TestGeometryHandler.cpp
@@ -17,7 +17,6 @@ struct ParsingResult {
 
 void parseAndTriangulate(const char *filePath, ParsingResult expectedResult, Catch::Benchmark::Chronometer meter) {
     ::RectCoord tileCoords = {Coord(3857,1224991.657211,6287508.342789,0), Coord(3857,1849991.657211,5662508.342789,0)};
-    const std::optional<Tiled2dMapVectorSettings> vectorSettings = std::nullopt;
     const auto conversionHelper = std::make_shared<CoordinateConversionHelper>(CoordinateSystemFactory::getEpsg3857System(), false);;
 
     auto data = TestData::readFileToBuffer(filePath);


### PR DESCRIPTION
In CMakeLists for android and JVM bindings, enable -Wunused and fix the resulting warnings in our code. This does not enable -Wunused-parameters; enabling this additionally leads to too many warnings right now.
Add djinni and other external library headers as system headers to suppress warnings in there. Unfortunately, clang thinks that some deprecation warnings need to be shown even in system headers, so we have to disable these globally.


- projectOntoUnitSphere was kept as an unused member in many opengl shaders
- persistingSymbolPlacement was apparently piped through to SymbolGroup and SymbolObject where it was not used
- a few non-trivial code snippets resulting in unused variables commented out instead of removing them.
