### PR TITLE
github: fix JVM release builds, use same runner for jvm_build and jvm_package_deploy

### DIFF
--- a/.github/workflows/jvm_build.yml
+++ b/.github/workflows/jvm_build.yml
@@ -6,10 +6,38 @@ on:
 jobs:
     build:
         name: Build JVM Project
-        uses: UbiqueInnovation/workflows-backend/.github/workflows/mvn_install.yml@main
-        with:
-            ref_name: ${{ github.sha }}
-            checkout_submodules: recursive
-            parent_pom: jvm/pom.xml
-            install_apt_packages: "cmake make clang libgl-dev libgles-dev libosmesa6-dev"
-            use_mvn_central: true
+        # Based on: UbiqueInnovation/workflows-backend/.github/workflows/mvn_install.yml
+        runs-on: ubuntu-24.04
+        steps:
+            -   uses: actions/checkout@v4
+                with:
+                    fetch-depth: 0
+                    submodules: recursive
+
+            -   name: Set up JDK
+                uses: actions/setup-java@v4
+                with:
+                    java-version: '21'
+                    distribution: 'temurin'
+
+            -   name: Cache Maven packages
+                uses: actions/cache@v4
+                with:
+                    path: ~/.m2/repository
+                    key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+                    restore-keys: |
+                      ${{ runner.os }}-m2-
+
+            -   name: ccache
+                uses: hendrikmuhs/ccache-action@v1.2
+                with:
+                  key: jvm-build-ccache-${{ runner.os }}-${{ runner.arch }}
+
+            -   name: Install build dependency apt packages
+                run: |
+                    sudo apt-get update && sudo apt-get install cmake make clang libgl-dev libgles-dev libosmesa6-dev
+
+            -   name: Build with Maven
+                env:
+                  CMAKE_CXX_COMPILER_LAUNCHER: ccache
+                run: mvn -f jvm/pom.xml --update-snapshots install

--- a/.github/workflows/jvm_package_deploy.yml
+++ b/.github/workflows/jvm_package_deploy.yml
@@ -13,11 +13,10 @@ jobs:
     build:
         name: Build JVM package and deploy to Maven repo
         # Based on: UbiqueInnovation/workflows-backend/.github/workflows/mvn_package_deploy.yml@feature/alt-deployment-repository
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-24.04
         steps:
             -   uses: actions/checkout@v4
                 with:
-                    fetch-depth: 0
                     submodules: recursive
 
             -   name: Set up JDK
@@ -31,11 +30,12 @@ jobs:
                 with:
                     path: ~/.m2/repository
                     key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-                    restore-keys: ${{ runner.os }}-m2-
+                    restore-keys: |
+                      ${{ runner.os }}-m2-
 
             -   name: Install build dependency apt packages
                 run: |
-                    sudo apt install cmake make clang libgl-dev libgles-dev libosmesa6-dev
+                    sudo apt-get update && sudo apt-get install cmake make clang libgl-dev libgles-dev libosmesa6-dev
 
             -   name: Create custom artifactory settings.xml
                 uses: whelk-io/maven-settings-xml-action@9dc09b23833fa9aa7f27b63db287951856f3433d


### PR DESCRIPTION
Release builds were failing because they were running on the older ubuntu github runners. This was different to the runners that was running the test build, which meant that some build problems (with older C++ library) only showed up during release build.

The reason to use the older runners was to ensure that we link against the ubuntu-22.04 glibc. This is no longer needed for our internal builds.

Also, expand the jvm_build job instead of using the workflow template (to set runs-on). This makes it easy to enable ccache.