### PR TITLE
OpenGL Simple Line Attribute Handling

### DIFF
--- a/android/src/main/cpp/graphics/objects/LineGroup2dOpenGl.cpp
+++ b/android/src/main/cpp/graphics/objects/LineGroup2dOpenGl.cpp
@@ -86,14 +86,20 @@ void LineGroup2dOpenGl::setup(const std::shared_ptr<::RenderingContextInterface>
     glEnableVertexAttribArray(extrudeHandle);
     glVertexAttribPointer(extrudeHandle, dimensionality, GL_FLOAT, false, stride, (float *)(sizeAttribGroup * 1));
 
-    glEnableVertexAttribArray(lineSideHandle);
-    glVertexAttribPointer(lineSideHandle, 1, GL_FLOAT, false, stride, (float *)(sizeAttribGroup * 2));
+    if (lineSideHandle >= 0) {
+        glEnableVertexAttribArray(lineSideHandle);
+        glVertexAttribPointer(lineSideHandle, 1, GL_FLOAT, false, stride, (float *) (sizeAttribGroup * 2));
+    }
 
-    glEnableVertexAttribArray(lengthPrefixHandle);
-    glVertexAttribPointer(lengthPrefixHandle, 1, GL_FLOAT, false, stride, (float *)(sizeAttribGroup * 2 + 1 * floatSize));
+    if (lengthPrefixHandle >= 0) {
+        glEnableVertexAttribArray(lengthPrefixHandle);
+        glVertexAttribPointer(lengthPrefixHandle, 1, GL_FLOAT, false, stride, (float *) (sizeAttribGroup * 2 + 1 * floatSize));
+    }
 
-    glEnableVertexAttribArray(lengthCorrectionHandle);
-    glVertexAttribPointer(lengthCorrectionHandle, 1, GL_FLOAT, false, stride, (float *)(sizeAttribGroup * 2 + 2 * floatSize));
+    if (lengthCorrectionHandle >= 0) {
+        glEnableVertexAttribArray(lengthCorrectionHandle);
+        glVertexAttribPointer(lengthCorrectionHandle, 1, GL_FLOAT, false, stride, (float *) (sizeAttribGroup * 2 + 2 * floatSize));
+    }
 
     glEnableVertexAttribArray(stylingIndexHandle);
     glVertexAttribPointer(stylingIndexHandle, 1, GL_FLOAT, false, stride, (float *)(sizeAttribGroup * 2 + 3 * floatSize));

--- a/android/src/main/cpp/graphics/objects/LineGroup2dOpenGl.h
+++ b/android/src/main/cpp/graphics/objects/LineGroup2dOpenGl.h
@@ -62,12 +62,12 @@ protected:
     int lineOriginHandle;
     int scaleFactorHandle;
 
-    int positionHandle;
-    int extrudeHandle;
-    int lineSideHandle;
-    int lengthPrefixHandle;
-    int lengthCorrectionHandle;
-    int stylingIndexHandle;
+    int positionHandle = -1;
+    int extrudeHandle = -1;
+    int lineSideHandle = -1;
+    int lengthPrefixHandle = -1;
+    int lengthCorrectionHandle = -1;
+    int stylingIndexHandle = -1;
 
     GLuint vao;
     GLuint vertexAttribBuffer = -1;


### PR DESCRIPTION
Don't try to set line group attribute ranges for non-available vertex attributes in simple line case.