### PR TITLE
correct vertex splitting logic in vector tile line processing

### DIFF
--- a/shared/src/map/layers/tiled/vector/tiles/line/Tiled2dMapVectorLineTile.h
+++ b/shared/src/map/layers/tiled/vector/tiles/line/Tiled2dMapVectorLineTile.h
@@ -52,7 +52,12 @@ private:
     void setupLines(const std::vector<std::shared_ptr<GraphicsObjectInterface>> &newLineGraphicsObjects);
 
 
+#ifdef OPENMOBILEMAPS_GL
     static const int maxNumLinePoints = std::numeric_limits<uint16_t>::max() / 4 + 1; // 4 vertices per line coord, only 2 at the start/end
+#else
+    static const int maxNumLinePoints = std::numeric_limits<uint32_t>::max() / 4 + 1; // on iOS we use 32 bit for the indices
+#endif
+
 #ifdef OPENMOBILEMAPS_GL
     static const int maxStylesPerGroup = 32;
 #else


### PR DESCRIPTION
Fix bug where styleGroupLineSubGroupVector.push_back() was adding new 
vectors instead of clearing the current styleGroupIndex position when 
splitting subgroups due to vertex limits.

This caused subsequent lines to be added to incorrect indices, breaking 
the grouping logic and preventing proper splitting of large vertex 
groups into multiple graphics objects.

Replace push_back with clear() to maintain correct index mapping while 
resetting the current subgroup for new lines.

And switched to 32bit limits on iOS since in the swift / metal code we already use 32 bit indices.