### PR TITLE
Bugfix/icon animations

### DIFF
--- a/shared/src/map/layers/tiled/vector/symbol/SymbolAnimationCoordinatorMap.h
+++ b/shared/src/map/layers/tiled/vector/symbol/SymbolAnimationCoordinatorMap.h
@@ -44,11 +44,6 @@ public:
         auto coordinatorIt = shard.animationCoordinators.find(crossTileIdentifier);
         if (coordinatorIt != shard.animationCoordinators.end()) {
             for (auto &[levelZoomIdentifier, coordinators]: coordinatorIt->second) {
-//                if (levelZoomIdentifier == zoomIdentifier) {
-//                    // limit comparisons with equal zoomIdentifier entries
-//                    continue;
-//                }
-
                 double toleranceFactor = 1 << std::max(0, levelZoomIdentifier - zoomIdentifier);
                 double maxXTolerance = toleranceFactor * xTolerance;
 

--- a/shared/src/map/layers/tiled/vector/symbol/SymbolAnimationCoordinatorMap.h
+++ b/shared/src/map/layers/tiled/vector/symbol/SymbolAnimationCoordinatorMap.h
@@ -44,10 +44,10 @@ public:
         auto coordinatorIt = shard.animationCoordinators.find(crossTileIdentifier);
         if (coordinatorIt != shard.animationCoordinators.end()) {
             for (auto &[levelZoomIdentifier, coordinators]: coordinatorIt->second) {
-                if (levelZoomIdentifier == zoomIdentifier) {
-                    // limit comparisons with equal zoomIdentifier entries
-                    continue;
-                }
+//                if (levelZoomIdentifier == zoomIdentifier) {
+//                    // limit comparisons with equal zoomIdentifier entries
+//                    continue;
+//                }
 
                 double toleranceFactor = 1 << std::max(0, levelZoomIdentifier - zoomIdentifier);
                 double maxXTolerance = toleranceFactor * xTolerance;
@@ -110,8 +110,7 @@ public:
                 ++next_it;
                 for (auto setIt = it->second.begin(), nextSetIt = setIt; setIt != it->second.end(); setIt = nextSetIt) {
                     ++nextSetIt;
-                    for (auto coordsIt = setIt->second.begin(); coordsIt != setIt->second.end();) {
-                        if (!coordsIt->get()->isUsed()) {
+                    for (auto coordsIt = setIt->second.begin(); coordsIt != setIt->second.end();) {                        if (!coordsIt->get()->isUsed()) {
                             coordsIt = setIt->second.erase(coordsIt);
                         } else {
                             ++coordsIt;

--- a/shared/src/map/layers/tiled/vector/symbol/SymbolAnimationCoordinatorMap.h
+++ b/shared/src/map/layers/tiled/vector/symbol/SymbolAnimationCoordinatorMap.h
@@ -105,7 +105,8 @@ public:
                 ++next_it;
                 for (auto setIt = it->second.begin(), nextSetIt = setIt; setIt != it->second.end(); setIt = nextSetIt) {
                     ++nextSetIt;
-                    for (auto coordsIt = setIt->second.begin(); coordsIt != setIt->second.end();) {                        if (!coordsIt->get()->isUsed()) {
+                    for (auto coordsIt = setIt->second.begin(); coordsIt != setIt->second.end();) {
+                        if (!coordsIt->get()->isUsed()) {
                             coordsIt = setIt->second.erase(coordsIt);
                         } else {
                             ++coordsIt;

--- a/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSymbolGroup.cpp
+++ b/shared/src/map/layers/tiled/vector/symbol/Tiled2dMapVectorSymbolGroup.cpp
@@ -319,7 +319,7 @@ void Tiled2dMapVectorSymbolGroup::initialize(std::weak_ptr<std::vector<Tiled2dMa
                         wasPlaced = true;
                     }
 
-                    if (hasIconPotentially) {
+                    if (hasIconPotentially && fullText != "") {
                         if (textOptional) {
                             const auto symbolObject = createSymbolObject(tileInfo, layerIdentifier, layerDescription, layerConfig,
                                                                          context, {}, "", mp, std::nullopt, fontList, anchor, angle,


### PR DESCRIPTION
Fixes two issues with icon animations:
- If an icon has an empty text, it might be added twice with the same cross tile identifier
- Generally, if a cross tile identifier has a collision for the same zoom level, its better to share the coordinator instead of overwriting the map an loosing the reference to the original coordinator