### PR TITLE
Camera 3d Config Animation Cancellation

### DIFF
--- a/shared/src/map/camera/MapCamera3d.cpp
+++ b/shared/src/map/camera/MapCamera3d.cpp
@@ -1600,11 +1600,11 @@ void MapCamera3d::setCameraConfig(const Camera3dConfig &config, std::optional<fl
             verticalDisplacementAnimation->cancel();
             verticalDisplacementAnimation = nullptr;
         }
-        if (zoomAnimation) {
+        if (targetZoom && zoomAnimation) {
             zoomAnimation->cancel();
             zoomAnimation = nullptr;
         }
-        if (coordAnimation) {
+        if (targetCoordinate && coordAnimation) {
             coordAnimation->cancel();
             coordAnimation = nullptr;
         }


### PR DESCRIPTION
Only cancel zoom/coordinate animations when starting new animations on setting the camera 3d config