### PR TITLE
github: jvm build workflow add permissions to push

### DIFF
--- a/.github/workflows/jvm_build.yml
+++ b/.github/workflows/jvm_build.yml
@@ -11,9 +11,9 @@ on:
         type: boolean
         default: false
 
-# Needed to write PR comments
+# Needed to write PR comments and push commits
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
Update workflow permissions to allow pushing updated test reference images.

Test run see #852.